### PR TITLE
fix(local-mcp): recover stale page sessions on navigation

### DIFF
--- a/packages/local-mcp/src/bridge.ts
+++ b/packages/local-mcp/src/bridge.ts
@@ -154,8 +154,11 @@ export async function startLocalMcpBridge(options: StartLocalMcpBridgeOptions): 
       return;
     }
     closed = true;
-    await server?.close();
-    await runtime.close();
+    const results = await Promise.allSettled([server?.close(), runtime.close()]);
+    const firstFailure = results.find((result): result is PromiseRejectedResult => result.status === "rejected");
+    if (firstFailure) {
+      throw firstFailure.reason;
+    }
   };
   try {
     const serverOptions: LocalMcpStdioServerOptions = {
@@ -193,7 +196,9 @@ export async function startLocalMcpBridge(options: StartLocalMcpBridgeOptions): 
 
   const input = options.input ?? process.stdin;
   const handleInputEnded = (): void => {
-    void closeResources().catch(options.onError);
+    void closeResources().catch((error) => {
+      options.onError?.(error);
+    });
   };
   input.once("end", handleInputEnded);
 

--- a/packages/local-mcp/src/runtime.ts
+++ b/packages/local-mcp/src/runtime.ts
@@ -19,6 +19,7 @@ import {
   webkit,
   type BrowserContext,
   type BrowserType,
+  type Frame,
   type Page,
 } from "playwright";
 import type { LocalMcpGateway } from "./server.js";
@@ -110,6 +111,17 @@ export function resolveTargetUrl(urlOverride: string | undefined, defaultUrl: st
     throw new Error("CONFIG_ERROR: no target url provided (missing --url and manifest.defaultUrl)");
   }
   return targetUrl;
+}
+
+export function resolveRecoveryNavigationUrl(
+  currentUrl: string | undefined,
+  targetUrl: string,
+  hostPatterns: string[],
+): string | undefined {
+  if (!currentUrl || !currentUrl.trim()) {
+    return targetUrl;
+  }
+  return isUrlAllowed(currentUrl, hostPatterns) ? undefined : targetUrl;
 }
 
 function resolveBrowserType(browser: BrowserEngine): BrowserType {
@@ -233,13 +245,21 @@ export async function startLocalMcpRuntime(options: LocalMcpRuntimeOptions): Pro
     const markGatewayStale = (): void => {
       gatewayStale = true;
     };
-    pageForEvents.on("framenavigated", markGatewayStale);
+    const handleFrameNavigation = (frame: Frame): void => {
+      if (frame === pageForEvents.mainFrame()) {
+        markGatewayStale();
+      }
+    };
+    pageForEvents.on("framenavigated", handleFrameNavigation);
     pageForEvents.on("close", markGatewayStale);
     pageLifecycleCleanup = (): void => {
       const pageEvents = pageForEvents as unknown as {
-        removeListener?: (event: string, listener: () => void) => unknown;
+        removeListener?: {
+          (event: "framenavigated", listener: (frame: Frame) => void): unknown;
+          (event: "close", listener: () => void): unknown;
+        };
       };
-      pageEvents.removeListener?.("framenavigated", markGatewayStale);
+      pageEvents.removeListener?.("framenavigated", handleFrameNavigation);
       pageEvents.removeListener?.("close", markGatewayStale);
     };
     if (navigate) {
@@ -277,6 +297,21 @@ export async function startLocalMcpRuntime(options: LocalMcpRuntimeOptions): Pro
     if (!currentPage || currentPage.isClosed()) {
       await initializePageSession(true);
       return;
+    }
+    const recoveryNavigationUrl = resolveRecoveryNavigationUrl(
+      currentPage.url(),
+      targetUrl,
+      site.manifest.hostPatterns,
+    );
+    if (recoveryNavigationUrl) {
+      try {
+        await currentPage.goto(recoveryNavigationUrl, {
+          waitUntil: "domcontentloaded",
+          timeout: NAVIGATION_TIMEOUT_MS,
+        });
+      } catch (error) {
+        throw mapNavigationError(error, recoveryNavigationUrl, "goto");
+      }
     }
     await initializePageSession(false);
   };

--- a/packages/local-mcp/test/bridge.test.ts
+++ b/packages/local-mcp/test/bridge.test.ts
@@ -50,12 +50,35 @@ describe("startLocalMcpBridge", () => {
     });
 
     input.emit("end");
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await vi.waitFor(() => {
+      expect(serverHandle.close).toHaveBeenCalledOnce();
+      expect(runtimeHandle.close).toHaveBeenCalledOnce();
+    });
 
     expect(serverHandle.start).toHaveBeenCalledOnce();
-    expect(serverHandle.close).toHaveBeenCalledOnce();
-    expect(runtimeHandle.close).toHaveBeenCalledOnce();
 
     await handle.close();
+  });
+
+  it("still closes the runtime when server cleanup fails", async () => {
+    serverHandle.close.mockImplementationOnce(async () => {
+      throw new Error("server close failed");
+    });
+    const onError = vi.fn();
+    const { startLocalMcpBridge } = await import("../src/bridge.js");
+    const input = new PassThrough();
+
+    await startLocalMcpBridge({
+      url: "http://127.0.0.1:4173",
+      serviceVersion: "0.1.0-test",
+      input,
+      onError,
+    });
+
+    input.emit("end");
+    await vi.waitFor(() => {
+      expect(runtimeHandle.close).toHaveBeenCalledOnce();
+      expect(onError).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/local-mcp/test/runtime.test.ts
+++ b/packages/local-mcp/test/runtime.test.ts
@@ -8,6 +8,7 @@ import {
   isRecoverableGatewayError,
   isUrlAllowed,
   mapNavigationError,
+  resolveRecoveryNavigationUrl,
   resolveTargetUrl,
   startLocalMcpRuntime,
 } from "../src/runtime.js";
@@ -83,6 +84,24 @@ describe("isRecoverableGatewayError", () => {
 
   it("rejects unrelated gateway failures", () => {
     expect(isRecoverableGatewayError(new Error("AUTH_REQUIRED: login required"))).toBe(false);
+  });
+});
+
+describe("resolveRecoveryNavigationUrl", () => {
+  it("reuses the current page when the host remains allowed", () => {
+    expect(
+      resolveRecoveryNavigationUrl("https://board.mix.space/session/123", "https://board.mix.space", [
+        "board.mix.space",
+      ]),
+    ).toBeUndefined();
+  });
+
+  it("navigates back to targetUrl when the current page is disallowed", () => {
+    expect(
+      resolveRecoveryNavigationUrl("https://example.com/other", "https://board.mix.space", [
+        "board.mix.space",
+      ]),
+    ).toBe("https://board.mix.space");
   });
 });
 


### PR DESCRIPTION
## Summary
- rebuild stale page gateways after navigation instead of forcing a fresh page load
- retry MCP tool operations once after recoverable page-context teardown errors
- close owned runtime resources when stdio input ends so the browser owner lifecycle stays tied to the bridge process

## Testing
- pnpm --filter @webmcp-bridge/local-mcp typecheck
- pnpm exec vitest run packages/local-mcp/test/runtime.test.ts packages/local-mcp/test/bridge.test.ts
- pnpm --filter @webmcp-bridge/local-mcp build
