### PR TITLE
fix(local-mcp): end owner session when window closes

### DIFF
--- a/packages/local-mcp/src/bridge.ts
+++ b/packages/local-mcp/src/bridge.ts
@@ -200,7 +200,13 @@ export async function startLocalMcpBridge(options: StartLocalMcpBridgeOptions): 
       options.onError?.(error);
     });
   };
+  const handleOwnerSessionEnded = (): void => {
+    void closeResources().catch((error) => {
+      options.onError?.(error);
+    });
+  };
   input.once("end", handleInputEnded);
+  void runtime.ownerSessionEnded.then(handleOwnerSessionEnded);
 
   return {
     site: runtime.site,

--- a/packages/local-mcp/src/runtime.ts
+++ b/packages/local-mcp/src/runtime.ts
@@ -62,6 +62,7 @@ export type LocalMcpRuntime = {
   headless: boolean;
   page: Page;
   gateway: LocalMcpGateway;
+  ownerSessionEnded: Promise<void>;
   openWindow: () => Promise<"focused" | "opened">;
   close: () => Promise<void>;
 };
@@ -122,6 +123,10 @@ export function resolveRecoveryNavigationUrl(
     return targetUrl;
   }
   return isUrlAllowed(currentUrl, hostPatterns) ? undefined : targetUrl;
+}
+
+export function shouldEndOwnerSessionAfterPageClose(headless: boolean, openPageCount: number): boolean {
+  return !headless && openPageCount === 0;
 }
 
 function resolveBrowserType(browser: BrowserEngine): BrowserType {
@@ -204,7 +209,21 @@ export async function startLocalMcpRuntime(options: LocalMcpRuntimeOptions): Pro
   let currentGatewaySession: WebMcpPageGateway | undefined;
   let currentMode: "native" | "polyfill" | "adapter-shim" = "native";
   let gatewayStale = false;
+  let runtimeClosing = false;
   let pageLifecycleCleanup: (() => void) | undefined;
+  let ownerSessionEndedResolved = false;
+  let resolveOwnerSessionEnded!: () => void;
+  const ownerSessionEnded = new Promise<void>((resolve) => {
+    resolveOwnerSessionEnded = resolve;
+  });
+
+  const signalOwnerSessionEnded = (): void => {
+    if (ownerSessionEndedResolved) {
+      return;
+    }
+    ownerSessionEndedResolved = true;
+    resolveOwnerSessionEnded();
+  };
 
   const cleanup = async (): Promise<void> => {
     await currentGatewaySession?.close().catch(() => {
@@ -245,13 +264,25 @@ export async function startLocalMcpRuntime(options: LocalMcpRuntimeOptions): Pro
     const markGatewayStale = (): void => {
       gatewayStale = true;
     };
+    const handlePageClose = (): void => {
+      markGatewayStale();
+      queueMicrotask(() => {
+        if (runtimeClosing) {
+          return;
+        }
+        const openPageCount = context?.pages().filter((entry) => !entry.isClosed()).length ?? 0;
+        if (shouldEndOwnerSessionAfterPageClose(headless, openPageCount)) {
+          signalOwnerSessionEnded();
+        }
+      });
+    };
     const handleFrameNavigation = (frame: Frame): void => {
       if (frame === pageForEvents.mainFrame()) {
         markGatewayStale();
       }
     };
     pageForEvents.on("framenavigated", handleFrameNavigation);
-    pageForEvents.on("close", markGatewayStale);
+    pageForEvents.on("close", handlePageClose);
     pageLifecycleCleanup = (): void => {
       const pageEvents = pageForEvents as unknown as {
         removeListener?: {
@@ -260,7 +291,7 @@ export async function startLocalMcpRuntime(options: LocalMcpRuntimeOptions): Pro
         };
       };
       pageEvents.removeListener?.("framenavigated", handleFrameNavigation);
-      pageEvents.removeListener?.("close", markGatewayStale);
+      pageEvents.removeListener?.("close", handlePageClose);
     };
     if (navigate) {
       try {
@@ -352,6 +383,7 @@ export async function startLocalMcpRuntime(options: LocalMcpRuntimeOptions): Pro
         return;
       }
       closed = true;
+      runtimeClosing = true;
       await cleanup();
     };
 
@@ -409,10 +441,12 @@ export async function startLocalMcpRuntime(options: LocalMcpRuntimeOptions): Pro
         return currentPage as Page;
       },
       gateway,
+      ownerSessionEnded,
       openWindow,
       close,
     };
   } catch (error) {
+    runtimeClosing = true;
     await cleanup();
     throw error;
   }

--- a/packages/local-mcp/test/bridge.test.ts
+++ b/packages/local-mcp/test/bridge.test.ts
@@ -6,6 +6,13 @@
 import { PassThrough } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+let resolveOwnerSessionEnded = (): void => {};
+function resetOwnerSessionEnded(): void {
+  runtimeHandle.ownerSessionEnded = new Promise<void>((resolve) => {
+    resolveOwnerSessionEnded = resolve;
+  });
+}
+
 const runtimeHandle = {
   site: "board",
   targetUrl: "http://127.0.0.1:4173",
@@ -16,6 +23,7 @@ const runtimeHandle = {
     callTool: vi.fn(async () => ({ ok: true })),
   },
   openWindow: vi.fn(async () => "focused" as const),
+  ownerSessionEnded: Promise.resolve(),
   close: vi.fn(async () => {}),
 };
 
@@ -33,7 +41,10 @@ vi.mock("../src/server.js", () => ({
 }));
 
 describe("startLocalMcpBridge", () => {
+  resetOwnerSessionEnded();
+
   afterEach(() => {
+    resetOwnerSessionEnded();
     runtimeHandle.close.mockClear();
     serverHandle.start.mockClear();
     serverHandle.close.mockClear();
@@ -79,6 +90,23 @@ describe("startLocalMcpBridge", () => {
     await vi.waitFor(() => {
       expect(runtimeHandle.close).toHaveBeenCalledOnce();
       expect(onError).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("closes resources when the runtime reports the owner window ended", async () => {
+    const { startLocalMcpBridge } = await import("../src/bridge.js");
+    const input = new PassThrough();
+
+    await startLocalMcpBridge({
+      url: "http://127.0.0.1:4173",
+      serviceVersion: "0.1.0-test",
+      input,
+    });
+
+    resolveOwnerSessionEnded();
+    await vi.waitFor(() => {
+      expect(serverHandle.close).toHaveBeenCalledOnce();
+      expect(runtimeHandle.close).toHaveBeenCalledOnce();
     });
   });
 });

--- a/packages/local-mcp/test/runtime.test.ts
+++ b/packages/local-mcp/test/runtime.test.ts
@@ -10,6 +10,7 @@ import {
   mapNavigationError,
   resolveRecoveryNavigationUrl,
   resolveTargetUrl,
+  shouldEndOwnerSessionAfterPageClose,
   startLocalMcpRuntime,
 } from "../src/runtime.js";
 
@@ -102,6 +103,20 @@ describe("resolveRecoveryNavigationUrl", () => {
         "board.mix.space",
       ]),
     ).toBe("https://board.mix.space");
+  });
+});
+
+describe("shouldEndOwnerSessionAfterPageClose", () => {
+  it("ends a headed owner session after the last page closes", () => {
+    expect(shouldEndOwnerSessionAfterPageClose(false, 0)).toBe(true);
+  });
+
+  it("keeps a headed owner session alive while another page is open", () => {
+    expect(shouldEndOwnerSessionAfterPageClose(false, 1)).toBe(false);
+  });
+
+  it("does not end a headless session from page-close semantics", () => {
+    expect(shouldEndOwnerSessionAfterPageClose(true, 0)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- end headed local-mcp owner sessions when the last browser window/page is closed by the user
- expose an `ownerSessionEnded` runtime signal and route it through the same bridge shutdown path used for stdin end / `bridge.close`
- cover the owner-window-close policy and bridge shutdown hookup with focused runtime/bridge tests

## Testing
- pnpm --filter @webmcp-bridge/local-mcp typecheck
- pnpm exec vitest run packages/local-mcp/test/runtime.test.ts packages/local-mcp/test/bridge.test.ts
- pnpm --filter @webmcp-bridge/local-mcp build
