### PR TITLE
feat(local-mcp): add auth-sensitive session lifecycle controls

### DIFF
--- a/docs/bridge-control-plane.md
+++ b/docs/bridge-control-plane.md
@@ -5,7 +5,7 @@
 - controls for the current browser runtime and window owned by the current stdio process;
 - controls for the longer-lived site session/profile lifecycle that may outlive one runtime.
 
-This document defines the reserved local control namespace and the next-step lifecycle model for auth-sensitive sites.
+This document defines the reserved local control namespace and the current lifecycle model for auth-sensitive sites.
 
 ## Problem
 
@@ -39,67 +39,117 @@ This keeps existing clients working while making the reserved namespace explicit
 
 ## Current Control Plane
 
-Implemented in this refactor:
+Implemented in the current control plane:
 
 - `bridge.window.open`
 - `bridge.session.status`
+- `bridge.session.bootstrap`
 - `bridge.session.attach`
 - `bridge.session.restart`
 - `bridge.session.stop`
+- `bridge.session.reset_profile`
 - legacy aliases: `bridge.open`, `bridge.close`
 
-`bridge.session.status` currently reports the runtime-scoped session view:
+`bridge.session.status` reports the local session view, not only the active runtime:
 
 - `site`
 - `targetUrl`
-- `controlMode` (`launch` | `attach`)
-- `browserUrl` (when attached)
-- `mode` (`native` | `polyfill` | `adapter-shim`)
+- `controlMode` (`none` | `bootstrap` | `launch` | `attach`)
+- `browserUrl` (when an attached browser is known)
+- `mode` (`native` | `polyfill` | `adapter-shim` | `control-only`)
 - `headless`
+- `authPolicyMode` (`none` | `bootstrap_then_attach`)
+- `authState` (`unknown` | `authenticated` | `auth_required` | `challenge_required`)
+- `sessionState`
+  - `profile_missing`
+  - `profile_present_unverified`
+  - `bootstrap_active`
+  - `auth_required`
+  - `challenge_required`
+  - `authenticated`
+  - `runtime_active`
+- `ownership` (`none` | `managed` | `external`)
+- `profilePath` (for managed-profile sessions)
+- `browserPid` (for a managed browser when known)
+- `lastBackupPath` (after `bridge.session.reset_profile`)
 
-`bridge.session.attach` and `bridge.session.restart` are the first executable lifecycle controls:
+`bridge.session.bootstrap`, `bridge.session.attach`, `bridge.session.restart`, and
+`bridge.session.reset_profile` are the executable lifecycle controls:
 
+- `bridge.session.bootstrap`
+  - for auth-sensitive managed sessions only
+  - launches a normal browser with the managed profile
+  - does not use Playwright launch for the sign-in flow
 - `bridge.session.attach`
-  - restarts the current bridge runtime into `attach` mode
-  - requires an explicit `browserUrl`
+  - attaches to an explicit external browser when `browserUrl` is provided
+  - otherwise, for auth-sensitive managed sessions, launches a managed attach browser and connects over CDP
 - `bridge.session.restart`
   - restarts the current bridge runtime in place
-  - can keep the current mode or switch between `launch` and `attach`
+  - supported for standard launch/attach sessions
+  - rejected for `bootstrap_then_attach` sessions when the requested mode is `launch`
+- `bridge.session.reset_profile`
+  - backs up the managed profile
+  - recreates an empty managed profile
+  - for auth-sensitive sessions, immediately re-enters bootstrap mode
 
-This is still intentionally narrow. It is enough to let clients switch runtime ownership without prematurely committing to a profile metadata format or a bootstrap browser launcher contract.
+## Session Metadata
 
-## Future Lifecycle Model
+Managed auth-sensitive sessions persist lightweight metadata beside the profile so the
+next `local-mcp` process can decide whether to:
 
-For auth-sensitive sites, the long-term target is:
+- bootstrap a normal browser for manual sign-in
+- reattach to an existing managed attach browser
+- start a fresh managed attach browser after a previous authenticated bootstrap
+
+The metadata records:
+
+- site id and target URL
+- auth policy mode and auth probe tool
+- session state and auth state
+- current control mode
+- ownership (`managed` or `external`)
+- managed attach `browserUrl` and `browserPid` when present
+- latest backup path after profile reset
+
+This metadata is intentionally local to `local-mcp`. It is not a daemon protocol and it
+does not attempt to own browser processes started by `uxc` or by the user outside the
+current control path.
+
+## Lifecycle Model
+
+For auth-sensitive sites, the active lifecycle is:
 
 1. `bootstrap`
    - launch a normal browser pointed at the managed profile
    - no Playwright-owned login flow
    - user completes sign-in manually
 2. `attach`
-   - restart in attach mode against the same profile/browser
+   - attach in CDP mode against the same profile/browser
    - Playwright controls the authenticated browser after sign-in
 
-This implies a future session state machine roughly like:
+This uses the following state machine:
 
 - `profile_missing`
 - `profile_present_unverified`
+- `bootstrap_active`
 - `auth_required`
 - `challenge_required`
 - `authenticated`
-- `attachable`
+- `runtime_active`
 
-The control-plane namespace leaves room for future methods such as:
+Startup decision for `authPolicy.mode = "bootstrap_then_attach"`:
 
-- `bridge.session.bootstrap`
-- `bridge.session.reset_profile`
+1. If an explicit `--browser-url` is provided, attach to that browser.
+2. Else if session metadata points to a running managed attach browser, reattach to it.
+3. Else if metadata says the managed profile is already authenticated, launch a managed attach browser and attach.
+4. Else launch bootstrap mode and wait for manual sign-in.
 
 ## Adapter Direction
 
 The bridge control plane should stay generic and site-agnostic.
 Site-specific auth behavior should continue to come from adapter manifests and adapter tools.
 
-Likely future adapter-facing shape:
+Current adapter-facing shape:
 
 ```ts
 type AuthPolicy = {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -13,7 +13,7 @@ node packages/local-mcp/dist/cli.js [--site <site> | --adapter-module <specifier
 
 ## Source selection
 
-- `--site <site>`: use built-in adapter preset (`x` or `fixture`).
+- `--site <site>`: use built-in adapter preset (`x`, `google`, or `fixture`).
 - `--adapter-module <specifier>`: use external adapter module (`npm` package name, file path, or `file://` URL).
 - If neither `--site` nor `--adapter-module` is provided, `--url` runs in native/polyfill mode (no adapter fallback).
 
@@ -37,18 +37,33 @@ node packages/local-mcp/dist/cli.js [--site <site> | --adapter-module <specifier
 - If the page exposes native `navigator.modelContext`, calls route to native WebMCP; otherwise the bridge falls back to injected adapters.
 - Polyfill mode: if native is unavailable, local-mcp injects `navigator.modelContext` compatibility APIs in-page.
 - Adapter-shim mode: when adapter source is configured and native is unavailable, fallback adapter logic handles tools.
+- Control-only mode: for auth-sensitive sessions that are waiting for bootstrap or attach, local-mcp exposes only reserved `bridge.*` tools and no page tools.
 - URL selection is `--url` first, otherwise adapter `manifest.defaultUrl`; startup fails closed if target host is outside adapter `hostPatterns`.
 - Stdio transport only in MVP.
 - local-mcp exposes a reserved `bridge.*` control namespace in addition to page tools:
   - `bridge.window.open`: focus the current headed browser session, or start a new headed session if the previous window was closed
   - `bridge.session.status`: return local-mcp control-plane state for the current site session
-  - `bridge.session.attach`: restart the current bridge session in CDP attach mode against an existing Chromium browser
+  - `bridge.session.bootstrap`: launch a normal browser for manual sign-in on a managed profile
+  - `bridge.session.attach`: attach in CDP mode, either to an explicit `browserUrl` or to a managed attach browser for auth-sensitive sessions
   - `bridge.session.restart`: restart the current bridge session, optionally switching control mode or headless state
   - `bridge.session.stop`: close the current bridge session
+  - `bridge.session.reset_profile`: back up and recreate the managed profile for the current session
   - `bridge.open` and `bridge.close` remain available as legacy aliases
 - `bridge.window.open` and `bridge.open` return `UNSUPPORTED_IN_HEADLESS_SESSION` when invoked through a headless link.
 - If `--browser-channel` is set, `--browser` must remain `chromium`; other engines reject channel overrides.
 - If `--browser-url` is set, local-mcp attaches to an already running Chromium browser and does not launch a new profile itself.
+- Auth-sensitive adapters declare `manifest.authPolicy`. When `authPolicy.mode = "bootstrap_then_attach"`, local-mcp uses a managed profile and follows this flow:
+  1. bootstrap a normal browser for manual sign-in
+  2. record lightweight session metadata beside the profile
+  3. attach to an authenticated browser over CDP for page automation
+- `bridge.session.status` includes:
+  - `controlMode`
+  - `mode`
+  - `authPolicyMode`
+  - `authState`
+  - `sessionState`
+  - `ownership`
+  - optional `profilePath`, `browserUrl`, `browserPid`, and `lastBackupPath`
 
 ## `uxc` demo shortcut
 

--- a/examples/board/tsconfig.json
+++ b/examples/board/tsconfig.json
@@ -12,6 +12,7 @@
       "@webmcp-bridge/core": ["packages/core/src/index.ts"],
       "@webmcp-bridge/playwright": ["packages/playwright/src/index.ts"],
       "@webmcp-bridge/local-mcp": ["packages/local-mcp/src/index.ts"],
+      "@webmcp-bridge/adapter-google": ["packages/adapter-google/src/index.ts"],
       "@webmcp-bridge/adapter-x": ["packages/adapter-x/src/index.ts"],
       "@webmcp-bridge/adapter-fixture": ["packages/adapter-fixture/src/index.ts"],
       "@webmcp-bridge/testkit": ["packages/testkit/src/index.ts"]

--- a/examples/board/vitest.config.ts
+++ b/examples/board/vitest.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
       "@webmcp-bridge/core": new URL("../../packages/core/src/index.ts", import.meta.url).pathname,
       "@webmcp-bridge/playwright": new URL("../../packages/playwright/src/index.ts", import.meta.url).pathname,
       "@webmcp-bridge/local-mcp": new URL("../../packages/local-mcp/src/index.ts", import.meta.url).pathname,
+      "@webmcp-bridge/adapter-google": new URL("../../packages/adapter-google/src/index.ts", import.meta.url)
+        .pathname,
       "@webmcp-bridge/adapter-x": new URL("../../packages/adapter-x/src/index.ts", import.meta.url).pathname,
       "@webmcp-bridge/adapter-fixture": new URL("../../packages/adapter-fixture/src/index.ts", import.meta.url).pathname,
       "@webmcp-bridge/testkit": new URL("../../packages/testkit/src/index.ts", import.meta.url).pathname,

--- a/packages/adapter-google/src/index.ts
+++ b/packages/adapter-google/src/index.ts
@@ -894,8 +894,11 @@ export const manifest: AdapterManifest = {
   bridgeApiVersion: "1.0.0",
   defaultUrl: GEMINI_URL,
   hostPatterns: ["google.com", "*.google.com"],
-  authProbeTool: "auth.get",
-  deferBridgeUntilAuthenticated: true,
+  authPolicy: {
+    mode: "bootstrap_then_attach",
+    authProbeTool: "auth.get",
+    allowAnonymousTools: true,
+  },
 };
 
 export function createAdapter(): SiteAdapter {

--- a/packages/adapter-x/src/index.ts
+++ b/packages/adapter-x/src/index.ts
@@ -13,7 +13,10 @@ export const manifest: AdapterManifest = {
   bridgeApiVersion: "1.0.0",
   defaultUrl: "https://x.com/home",
   hostPatterns: ["x.com", "www.x.com", "*.x.com"],
-  authProbeTool: "auth.get",
+  authPolicy: {
+    mode: "none",
+    authProbeTool: "auth.get",
+  },
 };
 
 export function createAdapter() {

--- a/packages/local-mcp/package.json
+++ b/packages/local-mcp/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@webmcp-bridge/adapter-fixture": "workspace:*",
+    "@webmcp-bridge/adapter-google": "workspace:*",
     "@webmcp-bridge/adapter-x": "workspace:*",
     "@webmcp-bridge/core": "workspace:*",
     "@webmcp-bridge/playwright": "workspace:*",

--- a/packages/local-mcp/src/bridge.ts
+++ b/packages/local-mcp/src/bridge.ts
@@ -1,22 +1,42 @@
 /**
  * This module composes runtime startup with the stdio MCP server into one lifecycle handle.
- * It depends on site-source resolution, runtime, and server modules so CLI and tests can start a complete local-mcp bridge in one call.
+ * It depends on site resolution, runtime startup, and session-control helpers so local-mcp can keep one MCP process alive across runtime, bootstrap, and attach transitions.
  */
 
 import type { Readable, Writable } from "node:stream";
 import {
   createLocalMcpStdioServer,
-  type LocalMcpStdioServer,
-  type LocalMcpStdioServerOptions,
   type LocalBridgeSessionRestartOptions,
   type LocalBridgeState,
+  type LocalMcpGateway,
+  type LocalMcpStdioServer,
+  type LocalMcpStdioServerOptions,
 } from "./server.js";
 import {
   startLocalMcpRuntime,
-  type LocalMcpRuntime,
-  type BrowserEngine,
   type BrowserChannel,
+  type BrowserEngine,
+  type LocalMcpRuntime,
 } from "./runtime.js";
+import {
+  assertAuthSensitiveBrowserSupport,
+  backupAndResetProfile,
+  describeSessionStateFromAuth,
+  ensureManagedProfile,
+  isProcessRunning,
+  launchBootstrapBrowser,
+  launchManagedAttachBrowser,
+  readSessionMetadata,
+  resolveAuthPolicy,
+  stopManagedBrowser,
+  updateSessionMetadata,
+  type BridgeAuthState,
+  type BridgeControlMode,
+  type BridgeSessionOwnership,
+  type BridgeSessionState,
+  type SessionMetadata,
+  type SessionMetadataPatch,
+} from "./session.js";
 import {
   createNativeSiteDefinition,
   resolveSiteSource,
@@ -46,180 +66,39 @@ export type StartLocalMcpBridgeOptions = {
 export type LocalMcpBridgeHandle = {
   site: string;
   targetUrl: string;
-  controlMode: "launch" | "attach";
-  mode: "native" | "polyfill" | "adapter-shim";
+  controlMode: BridgeControlMode;
+  mode: "native" | "polyfill" | "adapter-shim" | "control-only";
   headless: boolean;
   close: () => Promise<void>;
 };
 
-type AuthState = "authenticated" | "auth_required" | "challenge_required";
-type BridgeSessionConfig = {
-  controlMode: "launch" | "attach";
+type RuntimeMode = "native" | "polyfill" | "adapter-shim" | "control-only";
+type RuntimeStartOptions = {
+  siteDefinition: SiteDefinition;
+  url?: string;
+  browser?: BrowserEngine;
+  browserChannel?: BrowserChannel;
   browserUrl?: string;
-  headless: boolean;
+  chromiumLoginWorkaround?: boolean;
+  headless?: boolean;
+  userDataDir?: string;
+  preferNative?: boolean;
+  autoLoginFallback?: boolean;
 };
 
-function readAuthState(value: unknown): AuthState | undefined {
+function readAuthState(value: unknown): BridgeAuthState {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return undefined;
+    return "unknown";
   }
   const state = (value as { state?: unknown }).state;
   if (state === "authenticated" || state === "auth_required" || state === "challenge_required") {
     return state;
   }
-  return undefined;
+  return "unknown";
 }
 
-function createInitialSessionConfig(options: StartLocalMcpBridgeOptions): BridgeSessionConfig {
-  const sessionConfig: BridgeSessionConfig = {
-    controlMode: options.browserUrl ? "attach" : "launch",
-    headless: options.headless ?? false,
-  };
-  if (options.browserUrl !== undefined) {
-    sessionConfig.browserUrl = options.browserUrl;
-  }
-  return sessionConfig;
-}
-
-function createRuntimeStartOptions(
-  baseOptions: StartLocalMcpBridgeOptions,
-  sessionConfig: BridgeSessionConfig,
-): StartLocalMcpBridgeOptions {
-  const nextOptions: StartLocalMcpBridgeOptions = {
-    headless: sessionConfig.headless,
-    serviceVersion: baseOptions.serviceVersion,
-  };
-  if (baseOptions.browser !== undefined) {
-    nextOptions.browser = baseOptions.browser;
-  }
-  if (baseOptions.autoLoginFallback !== undefined) {
-    nextOptions.autoLoginFallback = baseOptions.autoLoginFallback;
-  }
-  if (baseOptions.site !== undefined) {
-    nextOptions.site = baseOptions.site;
-  }
-  if (baseOptions.adapterModule !== undefined) {
-    nextOptions.adapterModule = baseOptions.adapterModule;
-  }
-  if (baseOptions.moduleBaseDir !== undefined) {
-    nextOptions.moduleBaseDir = baseOptions.moduleBaseDir;
-  }
-  if (baseOptions.url !== undefined) {
-    nextOptions.url = baseOptions.url;
-  }
-  if (baseOptions.userDataDir !== undefined) {
-    nextOptions.userDataDir = baseOptions.userDataDir;
-  }
-  if (baseOptions.preferNative !== undefined) {
-    nextOptions.preferNative = baseOptions.preferNative;
-  }
-  if (sessionConfig.controlMode === "attach") {
-    if (baseOptions.browserChannel !== undefined) {
-      throw new Error("CONFIG_ERROR: --browser-url cannot be combined with --browser-channel");
-    }
-    if (baseOptions.chromiumLoginWorkaround !== undefined) {
-      throw new Error("CONFIG_ERROR: --browser-url cannot be combined with --chromium-login-workaround");
-    }
-    if (sessionConfig.browserUrl !== undefined) {
-      nextOptions.browserUrl = sessionConfig.browserUrl;
-    }
-    return nextOptions;
-  }
-  if (baseOptions.browserChannel !== undefined) {
-    nextOptions.browserChannel = baseOptions.browserChannel;
-  }
-  if (baseOptions.chromiumLoginWorkaround !== undefined) {
-    nextOptions.chromiumLoginWorkaround = baseOptions.chromiumLoginWorkaround;
-  }
-  return nextOptions;
-}
-
-function normalizeRestartSessionConfig(
-  currentSession: BridgeSessionConfig,
-  options: LocalBridgeSessionRestartOptions,
-): BridgeSessionConfig {
-  const requestedControlMode = options.controlMode ?? (options.browserUrl ? "attach" : currentSession.controlMode);
-  const headless = options.headless ?? currentSession.headless;
-  if (requestedControlMode === "attach") {
-    const browserUrl = options.browserUrl ?? currentSession.browserUrl;
-    if (!browserUrl) {
-      throw new Error("CONFIG_ERROR: bridge.session.attach requires browserUrl when no attach browser is active");
-    }
-    return {
-      controlMode: "attach",
-      browserUrl,
-      headless,
-    };
-  }
-  if (options.browserUrl !== undefined) {
-    throw new Error("CONFIG_ERROR: bridge.session.restart with controlMode=launch cannot accept browserUrl");
-  }
-  return {
-    controlMode: "launch",
-    headless,
-  };
-}
-
-function toBridgeState(runtime: LocalMcpRuntime, sessionConfig: BridgeSessionConfig): LocalBridgeState {
-  const state: LocalBridgeState = {
-    site: runtime.site,
-    targetUrl: runtime.targetUrl,
-    controlMode: runtime.controlMode,
-    mode: runtime.mode,
-    headless: runtime.headless,
-  };
-  if (sessionConfig.browserUrl !== undefined) {
-    state.browserUrl = sessionConfig.browserUrl;
-  }
-  return state;
-}
-
-async function startRuntime(
-  options: StartLocalMcpBridgeOptions,
-  siteDefinition: SiteDefinition,
-  headless: boolean,
-): Promise<LocalMcpRuntime> {
-  const runtimeOptions = {
-    siteDefinition,
-    headless,
-  } as {
-    siteDefinition: SiteDefinition;
-    headless: boolean;
-    url?: string;
-    browser?: BrowserEngine;
-    browserChannel?: BrowserChannel;
-    browserUrl?: string;
-    chromiumLoginWorkaround?: boolean;
-    userDataDir?: string;
-    preferNative?: boolean;
-  };
-  if (options.url !== undefined) {
-    runtimeOptions.url = options.url;
-  }
-  if (options.browser !== undefined) {
-    runtimeOptions.browser = options.browser;
-  }
-  if (options.userDataDir !== undefined) {
-    runtimeOptions.userDataDir = options.userDataDir;
-  }
-  if (options.browserChannel !== undefined) {
-    runtimeOptions.browserChannel = options.browserChannel;
-  }
-  if (options.browserUrl !== undefined) {
-    runtimeOptions.browserUrl = options.browserUrl;
-  }
-  if (options.chromiumLoginWorkaround !== undefined) {
-    runtimeOptions.chromiumLoginWorkaround = options.chromiumLoginWorkaround;
-  }
-  if (options.preferNative !== undefined) {
-    runtimeOptions.preferNative = options.preferNative;
-  }
-  return await startLocalMcpRuntime(runtimeOptions);
-}
-
-async function resolveRuntime(options: StartLocalMcpBridgeOptions): Promise<LocalMcpRuntime> {
+async function resolveSiteDefinitionFromBridgeOptions(options: StartLocalMcpBridgeOptions): Promise<SiteDefinition> {
   const hasAdapterSource = Boolean(options.site || options.adapterModule);
-  let siteDefinition: SiteDefinition;
   if (hasAdapterSource) {
     const sourceOptions = {} as {
       site?: string;
@@ -235,43 +114,90 @@ async function resolveRuntime(options: StartLocalMcpBridgeOptions): Promise<Loca
     if (options.moduleBaseDir !== undefined) {
       sourceOptions.moduleBaseDir = options.moduleBaseDir;
     }
-    siteDefinition = await resolveSiteSource(sourceOptions);
-  } else if (options.url) {
-    siteDefinition = createNativeSiteDefinition(options.url);
-  } else {
-    throw new Error("CONFIG_ERROR: provide --url or one of --site/--adapter-module");
+    return await resolveSiteSource(sourceOptions);
   }
-
-  const requestedHeadless = options.headless ?? false;
-  const primary = await startRuntime(options, siteDefinition, requestedHeadless);
-
-  const autoLoginFallback = options.autoLoginFallback ?? true;
-  const authProbeTool = siteDefinition.manifest.authProbeTool;
-  if (!autoLoginFallback || !requestedHeadless || !authProbeTool) {
-    return primary;
+  if (options.url) {
+    return createNativeSiteDefinition(options.url);
   }
+  throw new Error("CONFIG_ERROR: provide --url or one of --site/--adapter-module");
+}
 
-  try {
-    const authResult = await primary.gateway.callTool(authProbeTool, {});
-    const state = readAuthState(authResult);
-    if (state !== "auth_required" && state !== "challenge_required") {
-      return primary;
+async function startRuntime(options: RuntimeStartOptions): Promise<LocalMcpRuntime> {
+  return await startLocalMcpRuntime(options);
+}
+
+function buildRuntimeStartOptions(
+  baseOptions: StartLocalMcpBridgeOptions,
+  siteDefinition: SiteDefinition,
+  controlMode: "launch" | "attach",
+  headless: boolean,
+  browserUrl?: string,
+): RuntimeStartOptions {
+  const nextOptions: RuntimeStartOptions = {
+    siteDefinition,
+    headless,
+  };
+  if (baseOptions.url !== undefined) {
+    nextOptions.url = baseOptions.url;
+  }
+  if (baseOptions.browser !== undefined) {
+    nextOptions.browser = baseOptions.browser;
+  }
+  if (baseOptions.userDataDir !== undefined) {
+    nextOptions.userDataDir = baseOptions.userDataDir;
+  }
+  if (baseOptions.preferNative !== undefined) {
+    nextOptions.preferNative = baseOptions.preferNative;
+  }
+  if (baseOptions.autoLoginFallback !== undefined) {
+    nextOptions.autoLoginFallback = baseOptions.autoLoginFallback;
+  }
+  if (controlMode === "attach") {
+    if (!browserUrl) {
+      throw new Error("CONFIG_ERROR: attach mode requires a browserUrl");
     }
-  } catch {
-    // Ignore auth probing failures and keep current runtime.
-    return primary;
+    if (baseOptions.browserChannel !== undefined) {
+      throw new Error("CONFIG_ERROR: --browser-url cannot be combined with --browser-channel");
+    }
+    if (baseOptions.chromiumLoginWorkaround !== undefined) {
+      throw new Error("CONFIG_ERROR: --browser-url cannot be combined with --chromium-login-workaround");
+    }
+    nextOptions.browserUrl = browserUrl;
+    return nextOptions;
   }
-
-  await primary.close();
-  return await startRuntime(options, siteDefinition, false);
+  if (baseOptions.browserChannel !== undefined) {
+    nextOptions.browserChannel = baseOptions.browserChannel;
+  }
+  if (baseOptions.chromiumLoginWorkaround !== undefined) {
+    nextOptions.chromiumLoginWorkaround = baseOptions.chromiumLoginWorkaround;
+  }
+  return nextOptions;
 }
 
 export async function startLocalMcpBridge(options: StartLocalMcpBridgeOptions): Promise<LocalMcpBridgeHandle> {
-  const initialSessionConfig = createInitialSessionConfig(options);
-  const baseRuntimeOptions = createRuntimeStartOptions(options, initialSessionConfig);
-  let runtime = await resolveRuntime(baseRuntimeOptions);
-  let currentSessionConfig = initialSessionConfig;
+  const siteDefinition = await resolveSiteDefinitionFromBridgeOptions(options);
+  const authPolicy = resolveAuthPolicy(siteDefinition.manifest);
+  const targetUrl = options.url?.trim() || siteDefinition.manifest.defaultUrl?.trim() || "";
+  if (!targetUrl) {
+    throw new Error("CONFIG_ERROR: no target url provided (missing --url and manifest.defaultUrl)");
+  }
 
+  if (authPolicy.mode === "bootstrap_then_attach") {
+    assertAuthSensitiveBrowserSupport(options.browser, options.userDataDir);
+  }
+
+  let runtime: LocalMcpRuntime | undefined;
+  let runtimeMode: RuntimeMode = "control-only";
+  let controlMode: BridgeControlMode = "none";
+  let ownership: BridgeSessionOwnership = "none";
+  let authState: BridgeAuthState = "unknown";
+  let sessionState: BridgeSessionState =
+    authPolicy.mode === "bootstrap_then_attach" ? "profile_missing" : "runtime_active";
+  let browserUrl = options.browserUrl;
+  let browserPid: number | undefined;
+  let headless = options.headless ?? false;
+  let lastBackupPath: string | undefined;
+  let metadata: SessionMetadata | undefined;
   let server: LocalMcpStdioServer | undefined;
   let closed = false;
   let lifecycleTransition = Promise.resolve();
@@ -279,18 +205,74 @@ export async function startLocalMcpBridge(options: StartLocalMcpBridgeOptions): 
   let unsubscribeRuntimeResourceUpdates: (() => void) | undefined;
   let ownerSessionGeneration = 0;
 
-  const bindRuntime = (nextRuntime: LocalMcpRuntime, sessionConfig: BridgeSessionConfig): void => {
+  const profilePath = options.userDataDir;
+  const metadataFallback = profilePath
+    ? {
+        site: siteDefinition.id,
+        targetUrl,
+        authPolicy,
+      }
+    : undefined;
+
+  const refreshStatus = (): LocalBridgeState => {
+    const state: LocalBridgeState = {
+      site: siteDefinition.id,
+      targetUrl,
+      controlMode,
+      ...(browserUrl !== undefined ? { browserUrl } : {}),
+      mode: runtimeMode,
+      headless,
+      authPolicyMode: authPolicy.mode,
+      authState,
+      sessionState,
+      ownership,
+      ...(profilePath !== undefined ? { profilePath } : {}),
+      ...(browserPid !== undefined ? { browserPid } : {}),
+      ...(lastBackupPath !== undefined ? { lastBackupPath } : {}),
+    };
+    return state;
+  };
+
+  const syncFromMetadata = (nextMetadata: SessionMetadata): void => {
+    metadata = nextMetadata;
+    controlMode = nextMetadata.controlMode;
+    browserUrl = nextMetadata.browserUrl;
+    browserPid = nextMetadata.browserPid;
+    authState = nextMetadata.authState;
+    sessionState = nextMetadata.sessionState;
+    ownership = nextMetadata.ownership;
+    if (nextMetadata.lastBackupPath !== undefined) {
+      lastBackupPath = nextMetadata.lastBackupPath;
+    }
+    if (runtime === undefined) {
+      runtimeMode = "control-only";
+      headless = false;
+    }
+  };
+
+  const writeMetadata = async (patch: SessionMetadataPatch): Promise<void> => {
+    if (!profilePath || !metadataFallback) {
+      return;
+    }
+    const nextMetadata = await updateSessionMetadata(profilePath, metadataFallback, patch);
+    syncFromMetadata(nextMetadata);
+  };
+
+  const bindRuntime = (nextRuntime: LocalMcpRuntime, nextOwnership: BridgeSessionOwnership): void => {
     runtime = nextRuntime;
-    currentSessionConfig = sessionConfig;
+    runtimeMode = nextRuntime.mode;
+    controlMode = nextRuntime.controlMode;
+    headless = nextRuntime.headless;
+    ownership = nextOwnership;
     unsubscribeRuntimeResourceUpdates?.();
-    unsubscribeRuntimeResourceUpdates = runtime.gateway.onResourceUpdated((uri) => {
+    unsubscribeRuntimeResourceUpdates = nextRuntime.gateway.onResourceUpdated((uri) => {
       for (const listener of resourceUpdatedListeners) {
         listener(uri);
       }
     });
     ownerSessionGeneration += 1;
     const generation = ownerSessionGeneration;
-    void runtime.ownerSessionEnded.then(() => {
+    void nextRuntime.ownerSessionEnded.then(() => {
       if (closed || generation !== ownerSessionGeneration) {
         return;
       }
@@ -298,6 +280,49 @@ export async function startLocalMcpBridge(options: StartLocalMcpBridgeOptions): 
         options.onError?.(error);
       });
     });
+  };
+
+  const clearRuntime = (): void => {
+    runtime = undefined;
+    runtimeMode = "control-only";
+    unsubscribeRuntimeResourceUpdates?.();
+    unsubscribeRuntimeResourceUpdates = undefined;
+  };
+
+  const closeRuntime = async (): Promise<void> => {
+    if (!runtime) {
+      return;
+    }
+    const activeRuntime = runtime;
+    clearRuntime();
+    await activeRuntime.close();
+  };
+
+  const probeRuntimeAuthState = async (activeRuntime: LocalMcpRuntime): Promise<BridgeAuthState> => {
+    if (!authPolicy.authProbeTool) {
+      return "authenticated";
+    }
+    try {
+      const result = await activeRuntime.gateway.callTool(authPolicy.authProbeTool, {});
+      return readAuthState(result);
+    } catch {
+      return "unknown";
+    }
+  };
+
+  const closeResourcesInternal = async (): Promise<void> => {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    unsubscribeRuntimeResourceUpdates?.();
+    const activeRuntime = runtime;
+    clearRuntime();
+    const results = await Promise.allSettled([server?.close(), activeRuntime?.close()]);
+    const firstFailure = results.find((result): result is PromiseRejectedResult => result.status === "rejected");
+    if (firstFailure) {
+      throw firstFailure.reason;
+    }
   };
 
   const runLifecycleTransition = async <T>(operation: () => Promise<T>): Promise<T> => {
@@ -316,23 +341,146 @@ export async function startLocalMcpBridge(options: StartLocalMcpBridgeOptions): 
     }
   };
 
-  const closeResourcesInternal = async (): Promise<void> => {
-    if (closed) {
-      return;
-    }
-    closed = true;
-    unsubscribeRuntimeResourceUpdates?.();
-    const results = await Promise.allSettled([server?.close(), runtime.close()]);
-    const firstFailure = results.find((result): result is PromiseRejectedResult => result.status === "rejected");
-    if (firstFailure) {
-      throw firstFailure.reason;
-    }
-  };
-
   const closeResources = async (): Promise<void> => {
     await runLifecycleTransition(async () => {
       await closeResourcesInternal();
     });
+  };
+
+  const bootstrapSessionInternal = async (nextAuthState: BridgeAuthState = "unknown"): Promise<LocalBridgeState> => {
+    if (authPolicy.mode !== "bootstrap_then_attach" || !profilePath) {
+      throw new Error("UNSUPPORTED_SESSION_CONTROL: bootstrap is available only for auth-sensitive managed sessions");
+    }
+    await closeRuntime();
+    if (metadata?.ownership === "managed") {
+      await stopManagedBrowser(metadata);
+    }
+    await ensureManagedProfile(profilePath);
+    const bootstrapOptions = {
+      targetUrl,
+      userDataDir: profilePath,
+    } as {
+      targetUrl: string;
+      userDataDir: string;
+      browserChannel?: BrowserChannel;
+    };
+    if (options.browserChannel !== undefined) {
+      bootstrapOptions.browserChannel = options.browserChannel;
+    }
+    const launchResult = await launchBootstrapBrowser(bootstrapOptions);
+    const bootstrapPatch: SessionMetadataPatch = {
+      sessionState: nextAuthState === "unknown" ? "bootstrap_active" : describeSessionStateFromAuth(nextAuthState),
+      authState: nextAuthState,
+      controlMode: "bootstrap",
+      ownership: "external",
+      browserUrl: null,
+      browserPid: null,
+    };
+    if (launchResult.pid !== undefined) {
+      bootstrapPatch.browserPid = launchResult.pid;
+    }
+    await writeMetadata(bootstrapPatch);
+    return refreshStatus();
+  };
+
+  const activateRuntime = async (
+    nextRuntime: LocalMcpRuntime,
+    nextOwnership: BridgeSessionOwnership,
+    nextBrowserUrl?: string,
+    nextBrowserPid?: number,
+  ): Promise<LocalBridgeState> => {
+    const nextAuthState = await probeRuntimeAuthState(nextRuntime);
+    bindRuntime(nextRuntime, nextOwnership);
+    browserUrl = nextBrowserUrl;
+    browserPid = nextBrowserPid;
+    authState = nextAuthState;
+    sessionState = "runtime_active";
+    if (profilePath && metadataFallback) {
+      const runtimePatch: SessionMetadataPatch = {
+        sessionState: "runtime_active",
+        authState: nextAuthState,
+        controlMode: nextRuntime.controlMode,
+        ownership: nextOwnership,
+      };
+      if (nextBrowserUrl !== undefined) {
+        runtimePatch.browserUrl = nextBrowserUrl;
+      } else {
+        runtimePatch.browserUrl = null;
+      }
+      if (nextBrowserPid !== undefined) {
+        runtimePatch.browserPid = nextBrowserPid;
+      } else {
+        runtimePatch.browserPid = null;
+      }
+      await writeMetadata(runtimePatch);
+    }
+    return refreshStatus();
+  };
+
+  const attachSessionInternal = async (requestedBrowserUrl?: string): Promise<LocalBridgeState> => {
+    const explicitBrowserUrl = requestedBrowserUrl?.trim() || options.browserUrl?.trim();
+    const activeBrowserUrl = explicitBrowserUrl || browserUrl;
+    const nextOwnership: BridgeSessionOwnership = explicitBrowserUrl ? "external" : "managed";
+
+    if (runtime) {
+      await closeRuntime();
+    }
+
+    let managedAttachPid: number | undefined;
+    let attachBrowserUrl = activeBrowserUrl;
+
+    if (!attachBrowserUrl) {
+      if (authPolicy.mode !== "bootstrap_then_attach" || !profilePath) {
+        throw new Error("CONFIG_ERROR: bridge.session.attach requires browserUrl when no managed attach session exists");
+      }
+      await ensureManagedProfile(profilePath);
+      const attachOptions = {
+        targetUrl,
+        userDataDir: profilePath,
+      } as {
+        targetUrl: string;
+        userDataDir: string;
+        browserChannel?: BrowserChannel;
+      };
+      if (options.browserChannel !== undefined) {
+        attachOptions.browserChannel = options.browserChannel;
+      }
+      const managedAttach = await launchManagedAttachBrowser(attachOptions);
+      attachBrowserUrl = managedAttach.browserUrl;
+      managedAttachPid = managedAttach.pid;
+    }
+
+    try {
+      const nextRuntime = await startRuntime(
+        buildRuntimeStartOptions(options, siteDefinition, "attach", false, attachBrowserUrl),
+      );
+      const nextAuthState = await probeRuntimeAuthState(nextRuntime);
+      if (
+        authPolicy.mode === "bootstrap_then_attach" &&
+        !explicitBrowserUrl &&
+        (nextAuthState === "auth_required" || nextAuthState === "challenge_required")
+      ) {
+        await nextRuntime.close();
+        return await bootstrapSessionInternal(nextAuthState);
+      }
+      return await activateRuntime(nextRuntime, nextOwnership, attachBrowserUrl, managedAttachPid ?? browserPid);
+    } catch (error) {
+      if (managedAttachPid && profilePath && metadataFallback) {
+        const cleanupMetadata = await updateSessionMetadata(profilePath, metadataFallback, {
+          controlMode: "none",
+          ownership: "none",
+          browserUrl: null,
+          browserPid: null,
+        });
+        await stopManagedBrowser({
+          ...cleanupMetadata,
+          ownership: "managed",
+          browserPid: managedAttachPid,
+        });
+      }
+      await closeResourcesInternal().catch(options.onError);
+      throw error;
+    }
   };
 
   const restartRuntimeInternal = async (
@@ -341,27 +489,46 @@ export async function startLocalMcpBridge(options: StartLocalMcpBridgeOptions): 
     if (closed) {
       throw new Error("SESSION_NOT_AVAILABLE: local-mcp bridge session is closed");
     }
+    const requestedControlMode = restartOptions.controlMode ?? (controlMode === "attach" ? "attach" : "launch");
+    if (requestedControlMode === "attach") {
+      return await attachSessionInternal(restartOptions.browserUrl);
+    }
+    if (restartOptions.browserUrl !== undefined) {
+      throw new Error("CONFIG_ERROR: bridge.session.restart with controlMode=launch cannot accept browserUrl");
+    }
+    if (authPolicy.mode === "bootstrap_then_attach") {
+      throw new Error(
+        "UNSUPPORTED_SESSION_CONTROL: launch restarts are not supported for bootstrap_then_attach sessions",
+      );
+    }
 
     const previousRuntime = runtime;
-    const previousSessionConfig = currentSessionConfig;
-    const nextSessionConfig = normalizeRestartSessionConfig(previousSessionConfig, restartOptions);
-    await previousRuntime.close();
+    const previousState = refreshStatus();
+    await closeRuntime();
 
     try {
-      const nextRuntime = await resolveRuntime(createRuntimeStartOptions(options, nextSessionConfig));
-      bindRuntime(nextRuntime, nextSessionConfig);
-      return toBridgeState(nextRuntime, nextSessionConfig);
+      const nextRuntime = await startRuntime(
+        buildRuntimeStartOptions(
+          options,
+          siteDefinition,
+          "launch",
+          restartOptions.headless ?? (previousRuntime?.headless ?? (options.headless ?? false)),
+        ),
+      );
+      return await activateRuntime(nextRuntime, "managed");
     } catch (error) {
-      try {
-        const recoveredRuntime = await resolveRuntime(createRuntimeStartOptions(options, previousSessionConfig));
-        bindRuntime(recoveredRuntime, previousSessionConfig);
-      } catch (recoveryError) {
-        options.onError?.(recoveryError);
+      if (previousRuntime) {
         try {
-          await closeResourcesInternal();
-        } catch (closeError) {
-          options.onError?.(closeError);
+          const recoveredRuntime = await startRuntime(
+            buildRuntimeStartOptions(options, siteDefinition, "launch", previousState.headless),
+          );
+          await activateRuntime(recoveredRuntime, previousState.ownership);
+        } catch (recoveryError) {
+          options.onError?.(recoveryError);
+          await closeResourcesInternal().catch(options.onError);
         }
+      } else {
+        await closeResourcesInternal().catch(options.onError);
       }
       throw error;
     }
@@ -371,33 +538,128 @@ export async function startLocalMcpBridge(options: StartLocalMcpBridgeOptions): 
     return await runLifecycleTransition(async () => await restartRuntimeInternal(restartOptions));
   };
 
-  const gateway = {
-    listTools: async () => await runtime.gateway.listTools(),
-    callTool: async (name: string, input: Record<string, unknown>) => await runtime.gateway.callTool(name, input),
-    listResources: async () => await runtime.gateway.listResources(),
-    readResource: async (uri: string) => await runtime.gateway.readResource(uri),
-    onResourceUpdated: (listener: (uri: string) => void) => {
+  const resetProfileInternal = async (): Promise<LocalBridgeState> => {
+    if (!profilePath || !metadataFallback) {
+      throw new Error("UNSUPPORTED_SESSION_CONTROL: reset_profile requires a managed --user-data-dir");
+    }
+    await closeRuntime();
+    if (metadata?.ownership === "managed") {
+      await stopManagedBrowser(metadata);
+    }
+    const resetResult = await backupAndResetProfile(profilePath, metadataFallback);
+    syncFromMetadata(resetResult.metadata);
+    lastBackupPath = resetResult.backupPath;
+    if (authPolicy.mode === "bootstrap_then_attach") {
+      return await bootstrapSessionInternal();
+    }
+    return refreshStatus();
+  };
+
+  const initializeControlPlane = async (): Promise<void> => {
+    if (authPolicy.mode !== "bootstrap_then_attach") {
+      const nextControlMode = options.browserUrl ? "attach" : "launch";
+      const nextRuntime = await startRuntime(
+        buildRuntimeStartOptions(options, siteDefinition, nextControlMode, headless, options.browserUrl),
+      );
+      await activateRuntime(nextRuntime, nextControlMode === "attach" ? "external" : "managed", options.browserUrl);
+      return;
+    }
+
+    const managedProfilePath = profilePath as string;
+    metadata = await readSessionMetadata(managedProfilePath, metadataFallback as NonNullable<typeof metadataFallback>);
+    syncFromMetadata(metadata);
+
+    if (options.browserUrl) {
+      await attachSessionInternal(options.browserUrl);
+      return;
+    }
+
+    const hasRunningManagedAttach =
+      metadata.controlMode === "attach" &&
+      metadata.browserUrl !== undefined &&
+      metadata.ownership === "managed" &&
+      (await isProcessRunning(metadata.browserPid));
+    if (hasRunningManagedAttach) {
+      await attachSessionInternal(metadata.browserUrl);
+      return;
+    }
+
+    if (metadata.authState === "authenticated") {
+      await attachSessionInternal();
+      return;
+    }
+
+    await bootstrapSessionInternal(
+      metadata.authState === "auth_required" || metadata.authState === "challenge_required"
+        ? metadata.authState
+        : "unknown",
+    );
+  };
+
+  await initializeControlPlane();
+
+  const gateway: LocalMcpGateway = {
+    listTools: async () => {
+      if (!runtime) {
+        return [];
+      }
+      return await runtime.gateway.listTools();
+    },
+    callTool: async (name: string, input: Record<string, unknown>) => {
+      if (!runtime) {
+        throw new Error(
+          "SESSION_NOT_AVAILABLE: page tools are unavailable while local-mcp is waiting for bootstrap or attach",
+        );
+      }
+      return await runtime.gateway.callTool(name, input);
+    },
+    listResources: async () => {
+      if (!runtime) {
+        return [];
+      }
+      return await runtime.gateway.listResources();
+    },
+    readResource: async (uri: string) => {
+      if (!runtime) {
+        throw new Error(`RESOURCE_NOT_FOUND: ${uri}`);
+      }
+      return await runtime.gateway.readResource(uri);
+    },
+    onResourceUpdated: (listener) => {
       resourceUpdatedListeners.add(listener);
       return () => {
         resourceUpdatedListeners.delete(listener);
       };
     },
-  } satisfies LocalMcpStdioServerOptions["gateway"];
-
-  bindRuntime(runtime, initialSessionConfig);
+  };
 
   try {
     const serverOptions: LocalMcpStdioServerOptions = {
       gateway,
       bridgeControl: {
-        getState: () => toBridgeState(runtime, currentSessionConfig),
-        openWindow: async () => await runtime.openWindow(),
-        attachSession: async (browserUrl: string) =>
-          await restartRuntime({
-            controlMode: "attach",
-            browserUrl,
-          }),
+        getState: refreshStatus,
+        openWindow: async () => {
+          if (runtime) {
+            return await runtime.openWindow();
+          }
+          if (authPolicy.mode === "bootstrap_then_attach") {
+            await runLifecycleTransition(async () => {
+              await bootstrapSessionInternal(authState);
+            });
+            return "opened";
+          }
+          throw new Error("SESSION_NOT_AVAILABLE: current page is closed");
+        },
+        bootstrapSession: async () => {
+          return await runLifecycleTransition(async () => await bootstrapSessionInternal(authState));
+        },
+        attachSession: async (requestedBrowserUrl?: string) => {
+          return await runLifecycleTransition(async () => await attachSessionInternal(requestedBrowserUrl));
+        },
         restartSession: async (restartOptions: LocalBridgeSessionRestartOptions) => await restartRuntime(restartOptions),
+        resetProfile: async () => {
+          return await runLifecycleTransition(async () => await resetProfileInternal());
+        },
         closeBridge: async () => {
           await closeResources();
         },
@@ -417,8 +679,7 @@ export async function startLocalMcpBridge(options: StartLocalMcpBridgeOptions): 
     server = createLocalMcpStdioServer(serverOptions);
     await server.start();
   } catch (error) {
-    unsubscribeRuntimeResourceUpdates?.();
-    await runtime.close();
+    await closeResourcesInternal().catch(options.onError);
     throw error;
   }
 
@@ -432,19 +693,19 @@ export async function startLocalMcpBridge(options: StartLocalMcpBridgeOptions): 
 
   return {
     get site() {
-      return runtime.site;
+      return siteDefinition.id;
     },
     get targetUrl() {
-      return runtime.targetUrl;
+      return targetUrl;
     },
     get controlMode() {
-      return runtime.controlMode;
+      return controlMode;
     },
     get mode() {
-      return runtime.mode;
+      return runtimeMode;
     },
     get headless() {
-      return runtime.headless;
+      return headless;
     },
     close: async (): Promise<void> => {
       input.removeListener("end", handleInputEnded);

--- a/packages/local-mcp/src/cli.ts
+++ b/packages/local-mcp/src/cli.ts
@@ -31,7 +31,7 @@ const USAGE = `Usage:
   webmcp-local-mcp [--site <site> | --adapter-module <specifier>] [options]
 
 Source:
-  --site <site>                Built-in site id (currently: x, fixture)
+  --site <site>                Built-in site id (currently: x, google, fixture)
   --adapter-module <specifier> External adapter module (npm package, file path, or file:// URL)
   If neither source is provided, --url runs in native/polyfill mode without adapter fallback.
 

--- a/packages/local-mcp/src/runtime.ts
+++ b/packages/local-mcp/src/runtime.ts
@@ -26,6 +26,7 @@ import {
   type Page,
 } from "playwright";
 import type { LocalMcpGateway } from "./server.js";
+import { resolveAuthPolicy } from "./session.js";
 import type { SiteDefinition } from "./sites.js";
 
 const NAVIGATION_TIMEOUT_MS = 5_000;
@@ -443,9 +444,11 @@ export async function startLocalMcpRuntime(options: LocalMcpRuntimeOptions): Pro
   if (fallbackAdapterFactory) {
     gatewayOptions.fallbackAdapter = fallbackAdapterFactory();
   }
-  const authProbeTool = site.manifest.authProbeTool;
+  const authPolicy = resolveAuthPolicy(site.manifest);
+  const authProbeTool = authPolicy.authProbeTool;
   const deferBridgeUntilAuthenticated =
-    site.manifest.deferBridgeUntilAuthenticated === true &&
+    authPolicy.mode === "bootstrap_then_attach" &&
+    authPolicy.allowAnonymousTools &&
     typeof authProbeTool === "string" &&
     authProbeTool.length > 0 &&
     typeof fallbackAdapterFactory === "function";

--- a/packages/local-mcp/src/server.ts
+++ b/packages/local-mcp/src/server.ts
@@ -18,6 +18,12 @@ import {
 import type { WebMcpResourceDefinition, WebMcpToolDefinition } from "@webmcp-bridge/playwright";
 import type { Readable, Writable } from "node:stream";
 import type { McpToolDefinition } from "./mcp-types.js";
+import type {
+  BridgeAuthState,
+  BridgeControlMode,
+  BridgeSessionOwnership,
+  BridgeSessionState,
+} from "./session.js";
 
 export type LocalMcpGateway = {
   listTools: () => Promise<ReadonlyArray<WebMcpToolDefinition>>;
@@ -30,10 +36,17 @@ export type LocalMcpGateway = {
 export type LocalBridgeState = {
   site: string;
   targetUrl: string;
-  controlMode: "launch" | "attach";
+  controlMode: BridgeControlMode;
   browserUrl?: string;
-  mode: "native" | "polyfill" | "adapter-shim";
+  mode: "native" | "polyfill" | "adapter-shim" | "control-only";
   headless: boolean;
+  authPolicyMode: "none" | "bootstrap_then_attach";
+  authState: BridgeAuthState;
+  sessionState: BridgeSessionState;
+  ownership: BridgeSessionOwnership;
+  profilePath?: string;
+  browserPid?: number;
+  lastBackupPath?: string;
 };
 
 export type LocalBridgeSessionRestartOptions = {
@@ -45,8 +58,10 @@ export type LocalBridgeSessionRestartOptions = {
 export type LocalBridgeControl = {
   getState: () => LocalBridgeState;
   openWindow: () => Promise<"focused" | "opened">;
-  attachSession: (browserUrl: string) => Promise<LocalBridgeState>;
+  bootstrapSession: () => Promise<LocalBridgeState>;
+  attachSession: (browserUrl?: string) => Promise<LocalBridgeState>;
   restartSession: (options: LocalBridgeSessionRestartOptions) => Promise<LocalBridgeState>;
+  resetProfile: () => Promise<LocalBridgeState>;
   closeBridge: () => Promise<void>;
 };
 
@@ -349,6 +364,11 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
         },
       },
       {
+        name: "bridge.session.bootstrap",
+        description: "Launch a normal browser for manual sign-in on the managed site profile.",
+        inputSchema: { type: "object", additionalProperties: false },
+      },
+      {
         name: "bridge.session.attach",
         description: "Restart the current local-mcp bridge session in attach mode against an existing Chromium browser.",
         inputSchema: {
@@ -358,7 +378,6 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
               type: "string",
             },
           },
-          required: ["browserUrl"],
           additionalProperties: false,
         },
       },
@@ -388,6 +407,11 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
         inputSchema: { type: "object", additionalProperties: false },
       },
       {
+        name: "bridge.session.reset_profile",
+        description: "Back up and reset the managed browser profile for the current local-mcp bridge session.",
+        inputSchema: { type: "object", additionalProperties: false },
+      },
+      {
         name: "bridge.open",
         description: "Legacy alias for bridge.window.open.",
         inputSchema: { type: "object", additionalProperties: false },
@@ -409,18 +433,23 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
     return (
       name === "bridge.window.open" ||
       name === "bridge.session.status" ||
+      name === "bridge.session.bootstrap" ||
       name === "bridge.session.attach" ||
       name === "bridge.session.restart" ||
       name === "bridge.session.stop" ||
+      name === "bridge.session.reset_profile" ||
       name === "bridge.open" ||
       name === "bridge.close"
     );
   }
 
-  private parseRequiredBrowserUrl(input: Record<string, unknown>): string {
+  private parseOptionalBrowserUrl(input: Record<string, unknown>): string | undefined {
     const browserUrl = input.browserUrl;
+    if (browserUrl === undefined) {
+      return undefined;
+    }
     if (typeof browserUrl !== "string" || !browserUrl.trim()) {
-      throw new Error("INVALID_ARGUMENT: browserUrl must be a non-empty string");
+      throw new Error("INVALID_ARGUMENT: browserUrl must be a non-empty string when provided");
     }
     return browserUrl.trim();
   }
@@ -497,12 +526,31 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
           ...(state.browserUrl !== undefined ? { browserUrl: state.browserUrl } : {}),
           mode: state.mode,
           headless: state.headless,
+          authPolicyMode: state.authPolicyMode,
+          authState: state.authState,
+          sessionState: state.sessionState,
+          ownership: state.ownership,
+          ...(state.profilePath !== undefined ? { profilePath: state.profilePath } : {}),
+          ...(state.browserPid !== undefined ? { browserPid: state.browserPid } : {}),
+          ...(state.lastBackupPath !== undefined ? { lastBackupPath: state.lastBackupPath } : {}),
         },
       };
     }
+    if (name === "bridge.session.bootstrap") {
+      try {
+        const nextState = await options.bridgeControl.bootstrapSession();
+        return {
+          ok: true,
+          session: nextState,
+          bootstrapped: true,
+        };
+      } catch (error) {
+        return this.toBridgeErrorResult(error);
+      }
+    }
     if (name === "bridge.session.attach") {
       try {
-        const nextState = await options.bridgeControl.attachSession(this.parseRequiredBrowserUrl(input));
+        const nextState = await options.bridgeControl.attachSession(this.parseOptionalBrowserUrl(input));
         return {
           ok: true,
           session: nextState,
@@ -519,6 +567,18 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
           ok: true,
           session: nextState,
           restarted: true,
+        };
+      } catch (error) {
+        return this.toBridgeErrorResult(error);
+      }
+    }
+    if (name === "bridge.session.reset_profile") {
+      try {
+        const nextState = await options.bridgeControl.resetProfile();
+        return {
+          ok: true,
+          session: nextState,
+          reset: true,
         };
       } catch (error) {
         return this.toBridgeErrorResult(error);
@@ -545,6 +605,13 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
       ...(state.browserUrl !== undefined ? { browserUrl: state.browserUrl } : {}),
       mode: state.mode,
       headless: state.headless,
+      authPolicyMode: state.authPolicyMode,
+      authState: state.authState,
+      sessionState: state.sessionState,
+      ownership: state.ownership,
+      ...(state.profilePath !== undefined ? { profilePath: state.profilePath } : {}),
+      ...(state.browserPid !== undefined ? { browserPid: state.browserPid } : {}),
+      ...(state.lastBackupPath !== undefined ? { lastBackupPath: state.lastBackupPath } : {}),
       closing: true,
     };
   }

--- a/packages/local-mcp/src/session.ts
+++ b/packages/local-mcp/src/session.ts
@@ -1,0 +1,568 @@
+/**
+ * This module owns auth-policy normalization, managed profile metadata, and non-Playwright browser bootstrap helpers.
+ * It depends on adapter manifest types and Node process/filesystem APIs so local-mcp can orchestrate auth-sensitive sessions without introducing a daemon.
+ */
+
+import { access, mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { dirname, join } from "node:path";
+import { createServer } from "node:net";
+import type { AdapterManifest } from "@webmcp-bridge/playwright";
+import type { BrowserChannel, BrowserEngine } from "./runtime.js";
+
+export type BridgeAuthState = "unknown" | "authenticated" | "auth_required" | "challenge_required";
+export type BridgeSessionOwnership = "none" | "managed" | "external";
+export type BridgeSessionState =
+  | "profile_missing"
+  | "profile_present_unverified"
+  | "bootstrap_active"
+  | "auth_required"
+  | "challenge_required"
+  | "authenticated"
+  | "runtime_active";
+export type BridgeControlMode = "none" | "bootstrap" | "launch" | "attach";
+export type AuthPolicyMode = "none" | "bootstrap_then_attach";
+
+export type ResolvedAuthPolicy = {
+  mode: AuthPolicyMode;
+  authProbeTool?: string;
+  allowAnonymousTools: boolean;
+};
+
+export type SessionMetadata = {
+  version: 1;
+  site: string;
+  profilePath: string;
+  targetUrl: string;
+  authPolicyMode: AuthPolicyMode;
+  authProbeTool?: string;
+  allowAnonymousTools: boolean;
+  sessionState: BridgeSessionState;
+  authState: BridgeAuthState;
+  controlMode: BridgeControlMode;
+  ownership: BridgeSessionOwnership;
+  browserUrl?: string;
+  browserPid?: number;
+  lastBackupPath?: string;
+  updatedAt: string;
+};
+
+export type SessionMetadataPatch = Omit<Partial<SessionMetadata>, "browserUrl" | "browserPid" | "lastBackupPath"> & {
+  browserUrl?: string | null;
+  browserPid?: number | null;
+  lastBackupPath?: string | null;
+};
+
+export type BootstrapBrowserOptions = {
+  targetUrl: string;
+  userDataDir: string;
+  browserChannel?: BrowserChannel;
+};
+
+export type ManagedAttachBrowserOptions = BootstrapBrowserOptions;
+
+const SESSION_METADATA_VERSION = 1;
+const SESSION_METADATA_PATH = ".webmcp-bridge/session.json";
+const CDP_READY_TIMEOUT_MS = 10_000;
+const CDP_READY_POLL_INTERVAL_MS = 250;
+
+function timestamp(): string {
+  return new Date().toISOString();
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getSessionMetadataPath(userDataDir: string): string {
+  return join(userDataDir, SESSION_METADATA_PATH);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isBridgeAuthState(value: unknown): value is BridgeAuthState {
+  return (
+    value === "unknown" ||
+    value === "authenticated" ||
+    value === "auth_required" ||
+    value === "challenge_required"
+  );
+}
+
+function isBridgeSessionState(value: unknown): value is BridgeSessionState {
+  return (
+    value === "profile_missing" ||
+    value === "profile_present_unverified" ||
+    value === "bootstrap_active" ||
+    value === "auth_required" ||
+    value === "challenge_required" ||
+    value === "authenticated" ||
+    value === "runtime_active"
+  );
+}
+
+function isBridgeControlMode(value: unknown): value is BridgeControlMode {
+  return value === "none" || value === "bootstrap" || value === "launch" || value === "attach";
+}
+
+function isBridgeSessionOwnership(value: unknown): value is BridgeSessionOwnership {
+  return value === "none" || value === "managed" || value === "external";
+}
+
+function normalizeMetadata(
+  value: unknown,
+  fallback: {
+    site: string;
+    profilePath: string;
+    targetUrl: string;
+    authPolicy: ResolvedAuthPolicy;
+    profileExists: boolean;
+  },
+): SessionMetadata {
+  const base: SessionMetadata = {
+    version: SESSION_METADATA_VERSION,
+    site: fallback.site,
+    profilePath: fallback.profilePath,
+    targetUrl: fallback.targetUrl,
+    authPolicyMode: fallback.authPolicy.mode,
+    ...(fallback.authPolicy.authProbeTool !== undefined ? { authProbeTool: fallback.authPolicy.authProbeTool } : {}),
+    allowAnonymousTools: fallback.authPolicy.allowAnonymousTools,
+    sessionState: fallback.profileExists ? "profile_present_unverified" : "profile_missing",
+    authState: "unknown",
+    controlMode: "none",
+    ownership: "none",
+    updatedAt: timestamp(),
+  };
+
+  if (!isRecord(value)) {
+    return base;
+  }
+  const metadata = { ...base };
+  if (typeof value.site === "string" && value.site.trim()) {
+    metadata.site = value.site;
+  }
+  if (typeof value.profilePath === "string" && value.profilePath.trim()) {
+    metadata.profilePath = value.profilePath;
+  }
+  if (typeof value.targetUrl === "string" && value.targetUrl.trim()) {
+    metadata.targetUrl = value.targetUrl;
+  }
+  if (value.authPolicyMode === "none" || value.authPolicyMode === "bootstrap_then_attach") {
+    metadata.authPolicyMode = value.authPolicyMode;
+  }
+  if (typeof value.authProbeTool === "string" && value.authProbeTool.trim()) {
+    metadata.authProbeTool = value.authProbeTool;
+  }
+  if (typeof value.allowAnonymousTools === "boolean") {
+    metadata.allowAnonymousTools = value.allowAnonymousTools;
+  }
+  if (isBridgeSessionState(value.sessionState)) {
+    metadata.sessionState = value.sessionState;
+  }
+  if (isBridgeAuthState(value.authState)) {
+    metadata.authState = value.authState;
+  }
+  if (isBridgeControlMode(value.controlMode)) {
+    metadata.controlMode = value.controlMode;
+  }
+  if (isBridgeSessionOwnership(value.ownership)) {
+    metadata.ownership = value.ownership;
+  }
+  if (typeof value.browserUrl === "string" && value.browserUrl.trim()) {
+    metadata.browserUrl = value.browserUrl;
+  }
+  if (typeof value.browserPid === "number" && Number.isInteger(value.browserPid) && value.browserPid > 0) {
+    metadata.browserPid = value.browserPid;
+  }
+  if (typeof value.lastBackupPath === "string" && value.lastBackupPath.trim()) {
+    metadata.lastBackupPath = value.lastBackupPath;
+  }
+  if (typeof value.updatedAt === "string" && value.updatedAt.trim()) {
+    metadata.updatedAt = value.updatedAt;
+  }
+  return metadata;
+}
+
+export function resolveAuthPolicy(manifest: AdapterManifest): ResolvedAuthPolicy {
+  const declared = manifest.authPolicy;
+  if (declared) {
+    return {
+      mode: declared.mode,
+      ...(declared.authProbeTool !== undefined ? { authProbeTool: declared.authProbeTool } : {}),
+      allowAnonymousTools: declared.allowAnonymousTools ?? false,
+    };
+  }
+  const mode: AuthPolicyMode =
+    manifest.deferBridgeUntilAuthenticated === true ? "bootstrap_then_attach" : "none";
+  return {
+    mode,
+    ...(manifest.authProbeTool !== undefined ? { authProbeTool: manifest.authProbeTool } : {}),
+    allowAnonymousTools: manifest.deferBridgeUntilAuthenticated === true,
+  };
+}
+
+export async function ensureManagedProfile(userDataDir: string): Promise<void> {
+  await mkdir(userDataDir, { recursive: true });
+}
+
+export async function readSessionMetadata(
+  userDataDir: string,
+  fallback: {
+    site: string;
+    targetUrl: string;
+    authPolicy: ResolvedAuthPolicy;
+  },
+): Promise<SessionMetadata> {
+  const profileExists = await pathExists(userDataDir);
+  const metadataPath = getSessionMetadataPath(userDataDir);
+  if (!(await pathExists(metadataPath))) {
+    return normalizeMetadata(undefined, {
+      site: fallback.site,
+      profilePath: userDataDir,
+      targetUrl: fallback.targetUrl,
+      authPolicy: fallback.authPolicy,
+      profileExists,
+    });
+  }
+
+  try {
+    const parsed = JSON.parse(await readFile(metadataPath, "utf8")) as unknown;
+    return normalizeMetadata(parsed, {
+      site: fallback.site,
+      profilePath: userDataDir,
+      targetUrl: fallback.targetUrl,
+      authPolicy: fallback.authPolicy,
+      profileExists,
+    });
+  } catch {
+    return normalizeMetadata(undefined, {
+      site: fallback.site,
+      profilePath: userDataDir,
+      targetUrl: fallback.targetUrl,
+      authPolicy: fallback.authPolicy,
+      profileExists,
+    });
+  }
+}
+
+export async function writeSessionMetadata(userDataDir: string, metadata: SessionMetadata): Promise<void> {
+  const metadataPath = getSessionMetadataPath(userDataDir);
+  await mkdir(dirname(metadataPath), { recursive: true });
+  await writeFile(metadataPath, `${JSON.stringify({ ...metadata, version: SESSION_METADATA_VERSION }, null, 2)}\n`, "utf8");
+}
+
+export async function updateSessionMetadata(
+  userDataDir: string,
+  fallback: {
+    site: string;
+    targetUrl: string;
+    authPolicy: ResolvedAuthPolicy;
+  },
+  patch: SessionMetadataPatch,
+): Promise<SessionMetadata> {
+  const current = await readSessionMetadata(userDataDir, fallback);
+  const normalizedPatch = { ...patch } as Record<string, unknown>;
+  if (normalizedPatch.browserUrl === null) {
+    delete normalizedPatch.browserUrl;
+  }
+  if (normalizedPatch.browserPid === null) {
+    delete normalizedPatch.browserPid;
+  }
+  if (normalizedPatch.lastBackupPath === null) {
+    delete normalizedPatch.lastBackupPath;
+  }
+  const next: SessionMetadata = {
+    ...current,
+    ...(normalizedPatch as Partial<SessionMetadata>),
+    updatedAt: timestamp(),
+  };
+  if ("browserUrl" in patch && patch.browserUrl === null) {
+    delete next.browserUrl;
+  }
+  if ("browserPid" in patch && patch.browserPid === null) {
+    delete next.browserPid;
+  }
+  if ("lastBackupPath" in patch && patch.lastBackupPath === null) {
+    delete next.lastBackupPath;
+  }
+  await writeSessionMetadata(userDataDir, next);
+  return next;
+}
+
+export async function backupAndResetProfile(
+  userDataDir: string,
+  fallback: {
+    site: string;
+    targetUrl: string;
+    authPolicy: ResolvedAuthPolicy;
+  },
+): Promise<{ metadata: SessionMetadata; backupPath?: string }> {
+  let backupPath: string | undefined;
+  if (await pathExists(userDataDir)) {
+    const profileStat = await stat(userDataDir).catch(() => undefined);
+    if (profileStat?.isDirectory()) {
+      backupPath = `${userDataDir}-backup-${timestamp().replace(/[:.]/g, "-")}`;
+      await rename(userDataDir, backupPath);
+    } else {
+      await rm(userDataDir, { force: true, recursive: true });
+    }
+  }
+  await mkdir(userDataDir, { recursive: true });
+  const resetPatch: SessionMetadataPatch = {
+    sessionState: "profile_missing",
+    authState: "unknown",
+    controlMode: "none",
+    ownership: "none",
+    browserUrl: null,
+    browserPid: null,
+  };
+  if (backupPath !== undefined) {
+    resetPatch.lastBackupPath = backupPath;
+  }
+  const metadata = await updateSessionMetadata(userDataDir, fallback, resetPatch);
+  return { metadata, ...(backupPath !== undefined ? { backupPath } : {}) };
+}
+
+function getChromiumCandidates(channel: BrowserChannel | undefined): string[] {
+  if (process.env.WEBMCP_CHROMIUM_EXECUTABLE) {
+    return [process.env.WEBMCP_CHROMIUM_EXECUTABLE];
+  }
+  const normalizedChannel = channel ?? "chrome";
+  if (process.platform === "darwin") {
+    const appNames: Record<BrowserChannel, string> = {
+      chrome: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+      "chrome-beta": "/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta",
+      "chrome-dev": "/Applications/Google Chrome Dev.app/Contents/MacOS/Google Chrome Dev",
+      "chrome-canary": "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+      msedge: "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+      "msedge-beta": "/Applications/Microsoft Edge Beta.app/Contents/MacOS/Microsoft Edge Beta",
+      "msedge-dev": "/Applications/Microsoft Edge Dev.app/Contents/MacOS/Microsoft Edge Dev",
+      "msedge-canary": "/Applications/Microsoft Edge Canary.app/Contents/MacOS/Microsoft Edge Canary",
+    };
+    const fallback = [appNames.chrome, "/Applications/Chromium.app/Contents/MacOS/Chromium"];
+    return [appNames[normalizedChannel], ...fallback].filter(Boolean);
+  }
+  if (process.platform === "win32") {
+    const localAppData = process.env.LOCALAPPDATA ?? "";
+    const programFiles = process.env.PROGRAMFILES ?? "C:\\Program Files";
+    const programFilesX86 = process.env["PROGRAMFILES(X86)"] ?? "C:\\Program Files (x86)";
+    const candidates: Record<BrowserChannel, string[]> = {
+      chrome: [
+        `${programFiles}\\Google\\Chrome\\Application\\chrome.exe`,
+        `${programFilesX86}\\Google\\Chrome\\Application\\chrome.exe`,
+        `${localAppData}\\Google\\Chrome\\Application\\chrome.exe`,
+      ],
+      "chrome-beta": [
+        `${programFiles}\\Google\\Chrome Beta\\Application\\chrome.exe`,
+        `${programFilesX86}\\Google\\Chrome Beta\\Application\\chrome.exe`,
+        `${localAppData}\\Google\\Chrome Beta\\Application\\chrome.exe`,
+      ],
+      "chrome-dev": [`${localAppData}\\Google\\Chrome Dev\\Application\\chrome.exe`],
+      "chrome-canary": [`${localAppData}\\Google\\Chrome SxS\\Application\\chrome.exe`],
+      msedge: [
+        `${programFiles}\\Microsoft\\Edge\\Application\\msedge.exe`,
+        `${programFilesX86}\\Microsoft\\Edge\\Application\\msedge.exe`,
+      ],
+      "msedge-beta": [
+        `${programFiles}\\Microsoft\\Edge Beta\\Application\\msedge.exe`,
+        `${programFilesX86}\\Microsoft\\Edge Beta\\Application\\msedge.exe`,
+      ],
+      "msedge-dev": [
+        `${programFiles}\\Microsoft\\Edge Dev\\Application\\msedge.exe`,
+        `${programFilesX86}\\Microsoft\\Edge Dev\\Application\\msedge.exe`,
+      ],
+      "msedge-canary": [`${localAppData}\\Microsoft\\Edge SxS\\Application\\msedge.exe`],
+    };
+    return candidates[normalizedChannel];
+  }
+  const commands: Record<BrowserChannel, string[]> = {
+    chrome: ["google-chrome", "google-chrome-stable", "chromium-browser", "chromium"],
+    "chrome-beta": ["google-chrome-beta"],
+    "chrome-dev": ["google-chrome-unstable"],
+    "chrome-canary": ["google-chrome-canary"],
+    msedge: ["microsoft-edge", "microsoft-edge-stable"],
+    "msedge-beta": ["microsoft-edge-beta"],
+    "msedge-dev": ["microsoft-edge-dev"],
+    "msedge-canary": ["microsoft-edge-canary"],
+  };
+  return commands[normalizedChannel];
+}
+
+async function resolveChromiumExecutable(channel: BrowserChannel | undefined): Promise<string> {
+  const candidates = getChromiumCandidates(channel);
+  for (const candidate of candidates) {
+    if (!candidate) {
+      continue;
+    }
+    if (candidate.includes("/") || candidate.includes("\\") || candidate.endsWith(".exe")) {
+      if (await pathExists(candidate)) {
+        return candidate;
+      }
+      continue;
+    }
+    return candidate;
+  }
+  throw new Error(
+    "BROWSER_NOT_FOUND: unable to locate a Chromium browser for bootstrap/attach. Set WEBMCP_CHROMIUM_EXECUTABLE or install a supported browser channel.",
+  );
+}
+
+function buildBootstrapArgs(options: BootstrapBrowserOptions): string[] {
+  return [
+    `--user-data-dir=${options.userDataDir}`,
+    "--disable-extensions",
+    "--no-first-run",
+    "--no-default-browser-check",
+    "--new-window",
+    options.targetUrl,
+  ];
+}
+
+async function reservePort(): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => {
+          reject(new Error("PORT_RESERVATION_FAILED: unable to allocate a debugging port"));
+        });
+        return;
+      }
+      const { port } = address;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(port);
+      });
+    });
+  });
+}
+
+async function waitForCdp(browserUrl: string, timeoutMs = CDP_READY_TIMEOUT_MS): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${browserUrl}/json/version`);
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // Retry until timeout while the browser starts.
+    }
+    await new Promise((resolve) => setTimeout(resolve, CDP_READY_POLL_INTERVAL_MS));
+  }
+  throw new Error(`BROWSER_ATTACH_TIMEOUT: timed out waiting for remote debugging at ${browserUrl}`);
+}
+
+function spawnDetachedBrowser(executable: string, args: string[]): number | undefined {
+  const child = spawn(executable, args, {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
+  return child.pid ?? undefined;
+}
+
+export async function launchBootstrapBrowser(options: BootstrapBrowserOptions): Promise<{ pid?: number }> {
+  const executable = await resolveChromiumExecutable(options.browserChannel);
+  const pid = spawnDetachedBrowser(executable, buildBootstrapArgs(options));
+  return { ...(pid !== undefined ? { pid } : {}) };
+}
+
+export async function launchManagedAttachBrowser(
+  options: ManagedAttachBrowserOptions,
+): Promise<{ browserUrl: string; pid?: number }> {
+  const executable = await resolveChromiumExecutable(options.browserChannel);
+  const port = await reservePort();
+  const browserUrl = `http://127.0.0.1:${port}`;
+  const pid = spawnDetachedBrowser(executable, [
+    `--user-data-dir=${options.userDataDir}`,
+    "--disable-extensions",
+    "--no-first-run",
+    "--no-default-browser-check",
+    `--remote-debugging-port=${port}`,
+    "--new-window",
+    options.targetUrl,
+  ]);
+  await waitForCdp(browserUrl);
+  return {
+    browserUrl,
+    ...(pid !== undefined ? { pid } : {}),
+  };
+}
+
+export async function isProcessRunning(pid: number | undefined): Promise<boolean> {
+  if (!pid) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function stopManagedBrowser(metadata: SessionMetadata): Promise<void> {
+  if (metadata.ownership !== "managed" || !(await isProcessRunning(metadata.browserPid))) {
+    return;
+  }
+  if (process.platform === "win32") {
+    await new Promise<void>((resolve) => {
+      const child = spawn("taskkill", ["/PID", String(metadata.browserPid), "/T", "/F"], {
+        stdio: "ignore",
+      });
+      child.once("exit", () => resolve());
+      child.once("error", () => resolve());
+    });
+    return;
+  }
+  try {
+    process.kill(-(metadata.browserPid as number), "SIGTERM");
+  } catch {
+    try {
+      process.kill(metadata.browserPid as number, "SIGTERM");
+    } catch {
+      // Ignore missing/stale processes during cleanup.
+    }
+  }
+}
+
+export function assertAuthSensitiveBrowserSupport(
+  browser: BrowserEngine | undefined,
+  userDataDir: string | undefined,
+): void {
+  const browserEngine = browser ?? "chromium";
+  if (browserEngine !== "chromium") {
+    throw new Error(
+      `CONFIG_ERROR: auth-sensitive bootstrap/attach sessions require --browser chromium (received ${browserEngine})`,
+    );
+  }
+  if (!userDataDir) {
+    throw new Error("CONFIG_ERROR: auth-sensitive bootstrap/attach sessions require --user-data-dir");
+  }
+}
+
+export function describeSessionStateFromAuth(authState: BridgeAuthState): BridgeSessionState {
+  if (authState === "authenticated") {
+    return "authenticated";
+  }
+  if (authState === "challenge_required") {
+    return "challenge_required";
+  }
+  if (authState === "auth_required") {
+    return "auth_required";
+  }
+  return "profile_present_unverified";
+}

--- a/packages/local-mcp/src/sites.ts
+++ b/packages/local-mcp/src/sites.ts
@@ -10,6 +10,10 @@ import {
   manifest as fixtureManifest,
 } from "@webmcp-bridge/adapter-fixture";
 import {
+  createAdapter as createGoogleAdapter,
+  manifest as googleManifest,
+} from "@webmcp-bridge/adapter-google";
+import {
   createAdapter as createXAdapter,
   manifest as xManifest,
 } from "@webmcp-bridge/adapter-x";
@@ -19,7 +23,7 @@ import type {
   SiteAdapterModule,
 } from "@webmcp-bridge/playwright";
 
-export type BuiltinSite = "x" | "fixture";
+export type BuiltinSite = "x" | "google" | "fixture";
 
 export type SiteDefinition = {
   id: string;
@@ -41,6 +45,12 @@ const BUILTIN_SITE_DEFINITIONS: Record<BuiltinSite, SiteDefinition> = {
     source: "builtin",
     manifest: xManifest,
     createFallbackAdapter: () => createXAdapter(),
+  },
+  google: {
+    id: "google",
+    source: "builtin",
+    manifest: googleManifest,
+    createFallbackAdapter: () => createGoogleAdapter(),
   },
   fixture: {
     id: "fixture",
@@ -71,6 +81,7 @@ function validateManifest(value: unknown): AdapterManifest {
   const hostPatterns = value.hostPatterns;
   const authProbeTool = value.authProbeTool;
   const deferBridgeUntilAuthenticated = value.deferBridgeUntilAuthenticated;
+  const authPolicy = value.authPolicy;
 
   if (!isNonEmptyString(id)) {
     throw new Error("ADAPTER_CONTRACT_ERROR: manifest.id must be a non-empty string");
@@ -104,6 +115,29 @@ function validateManifest(value: unknown): AdapterManifest {
       "ADAPTER_CONTRACT_ERROR: manifest.deferBridgeUntilAuthenticated must be a boolean when provided",
     );
   }
+  if (authPolicy !== undefined) {
+    if (!isRecord(authPolicy)) {
+      throw new Error("ADAPTER_CONTRACT_ERROR: manifest.authPolicy must be an object when provided");
+    }
+    if (authPolicy.mode !== "none" && authPolicy.mode !== "bootstrap_then_attach") {
+      throw new Error(
+        "ADAPTER_CONTRACT_ERROR: manifest.authPolicy.mode must be none or bootstrap_then_attach",
+      );
+    }
+    if (authPolicy.authProbeTool !== undefined && !isNonEmptyString(authPolicy.authProbeTool)) {
+      throw new Error(
+        "ADAPTER_CONTRACT_ERROR: manifest.authPolicy.authProbeTool must be a non-empty string when provided",
+      );
+    }
+    if (
+      authPolicy.allowAnonymousTools !== undefined &&
+      typeof authPolicy.allowAnonymousTools !== "boolean"
+    ) {
+      throw new Error(
+        "ADAPTER_CONTRACT_ERROR: manifest.authPolicy.allowAnonymousTools must be a boolean when provided",
+      );
+    }
+  }
 
   const output: AdapterManifest = {
     id,
@@ -120,6 +154,28 @@ function validateManifest(value: unknown): AdapterManifest {
   }
   if (deferBridgeUntilAuthenticated !== undefined) {
     output.deferBridgeUntilAuthenticated = deferBridgeUntilAuthenticated;
+  }
+  if (authPolicy !== undefined) {
+    const normalizedAuthPolicy = authPolicy as {
+      mode: "none" | "bootstrap_then_attach";
+      authProbeTool?: string;
+      allowAnonymousTools?: boolean;
+    };
+    output.authPolicy = {
+      mode: normalizedAuthPolicy.mode,
+      ...(normalizedAuthPolicy.authProbeTool !== undefined
+        ? { authProbeTool: normalizedAuthPolicy.authProbeTool }
+        : {}),
+      ...(normalizedAuthPolicy.allowAnonymousTools !== undefined
+        ? { allowAnonymousTools: normalizedAuthPolicy.allowAnonymousTools }
+        : {}),
+    };
+  } else if (authProbeTool !== undefined || deferBridgeUntilAuthenticated !== undefined) {
+    output.authPolicy = {
+      mode: deferBridgeUntilAuthenticated === true ? "bootstrap_then_attach" : "none",
+      ...(authProbeTool !== undefined ? { authProbeTool } : {}),
+      ...(deferBridgeUntilAuthenticated === true ? { allowAnonymousTools: true } : {}),
+    };
   }
   return output;
 }

--- a/packages/local-mcp/test/cli.test.ts
+++ b/packages/local-mcp/test/cli.test.ts
@@ -75,6 +75,11 @@ describe("parseCliArgs", () => {
     expect(parsed.autoLoginFallback).toBe(true);
   });
 
+  it("parses google site id", () => {
+    const parsed = parseCliArgs(["--site", "google"]);
+    expect(parsed.site).toBe("google");
+  });
+
   it("allows disabling auto login fallback", () => {
     const parsed = parseCliArgs(["--site", "x", "--headless", "--no-auto-login-fallback"]);
     expect(parsed.headless).toBe(true);
@@ -129,6 +134,12 @@ describe("resolveSiteDefinition", () => {
     const site = resolveSiteDefinition("fixture");
     expect(site.manifest.defaultUrl).toBe("about:blank");
     expect(site.manifest.hostPatterns).toContain("about:blank");
+  });
+
+  it("resolves google site preset", () => {
+    const site = resolveSiteDefinition("google");
+    expect(site.manifest.defaultUrl).toContain("gemini.google.com");
+    expect(site.manifest.hostPatterns).toContain("google.com");
   });
 
   it("throws on unsupported site", () => {

--- a/packages/local-mcp/test/server.test.ts
+++ b/packages/local-mcp/test/server.test.ts
@@ -72,15 +72,35 @@ describe("createLocalMcpStdioServer", () => {
       site: "board",
       targetUrl: "http://127.0.0.1:4173",
       controlMode: "launch" as const,
+      authPolicyMode: "none" as const,
+      authState: "unknown" as const,
+      sessionState: "runtime_active" as const,
+      ownership: "managed" as const,
       mode: "native" as const,
       headless: false,
     })),
     openWindow: vi.fn<() => Promise<"focused" | "opened">>(async () => "focused" as const),
+    bootstrapSession: vi.fn(async () => ({
+      site: "board",
+      targetUrl: "http://127.0.0.1:4173",
+      controlMode: "bootstrap" as const,
+      authPolicyMode: "bootstrap_then_attach" as const,
+      authState: "auth_required" as const,
+      sessionState: "bootstrap_active" as const,
+      ownership: "external" as const,
+      mode: "control-only" as const,
+      headless: false,
+      profilePath: "/tmp/board-profile",
+    })),
     attachSession: vi.fn(async () => ({
       site: "board",
       targetUrl: "http://127.0.0.1:4173",
       controlMode: "attach" as const,
       browserUrl: "http://127.0.0.1:9222",
+      authPolicyMode: "bootstrap_then_attach" as const,
+      authState: "authenticated" as const,
+      sessionState: "runtime_active" as const,
+      ownership: "external" as const,
       mode: "native" as const,
       headless: false,
     })),
@@ -88,8 +108,25 @@ describe("createLocalMcpStdioServer", () => {
       site: "board",
       targetUrl: "http://127.0.0.1:4173",
       controlMode: "launch" as const,
+      authPolicyMode: "none" as const,
+      authState: "authenticated" as const,
+      sessionState: "runtime_active" as const,
+      ownership: "managed" as const,
       mode: "native" as const,
       headless: true,
+    })),
+    resetProfile: vi.fn(async () => ({
+      site: "board",
+      targetUrl: "http://127.0.0.1:4173",
+      controlMode: "bootstrap" as const,
+      authPolicyMode: "bootstrap_then_attach" as const,
+      authState: "unknown" as const,
+      sessionState: "bootstrap_active" as const,
+      ownership: "external" as const,
+      mode: "control-only" as const,
+      headless: false,
+      profilePath: "/tmp/board-profile",
+      lastBackupPath: "/tmp/board-profile-backup",
     })),
     closeBridge: vi.fn(async () => {}),
   };
@@ -106,8 +143,10 @@ describe("createLocalMcpStdioServer", () => {
     onResourceUpdated.mockClear();
     bridgeControl.getState.mockClear();
     bridgeControl.openWindow.mockClear();
+    bridgeControl.bootstrapSession.mockClear();
     bridgeControl.attachSession.mockClear();
     bridgeControl.restartSession.mockClear();
+    bridgeControl.resetProfile.mockClear();
     bridgeControl.closeBridge.mockClear();
 
     output.on("data", (chunk: Buffer | string) => {
@@ -202,9 +241,11 @@ describe("createLocalMcpStdioServer", () => {
       tools: [
         { name: "bridge.window.open" },
         { name: "bridge.session.status" },
+        { name: "bridge.session.bootstrap" },
         { name: "bridge.session.attach" },
         { name: "bridge.session.restart" },
         { name: "bridge.session.stop" },
+        { name: "bridge.session.reset_profile" },
         { name: "bridge.open" },
         { name: "bridge.close" },
         { name: "ping" },
@@ -369,7 +410,7 @@ describe("createLocalMcpStdioServer", () => {
     });
   });
 
-  it("rejects invalid bridge.session.attach input", async () => {
+  it("allows bridge.session.attach without an explicit browserUrl", async () => {
     const response = await request({
       jsonrpc: "2.0",
       id: "2ce",
@@ -380,12 +421,37 @@ describe("createLocalMcpStdioServer", () => {
       },
     });
 
-    expect(bridgeControl.attachSession).not.toHaveBeenCalled();
+    expect(bridgeControl.attachSession).toHaveBeenCalledWith(undefined);
     expect("result" in response ? response.result : undefined).toMatchObject({
       structuredContent: {
-        ok: false,
-        error: {
-          code: "INVALID_ARGUMENT",
+        ok: true,
+        restarted: true,
+        session: {
+          controlMode: "attach",
+        },
+      },
+    });
+  });
+
+  it("handles bridge.session.bootstrap locally", async () => {
+    const response = await request({
+      jsonrpc: "2.0",
+      id: "2ce-bootstrap",
+      method: "tools/call",
+      params: {
+        name: "bridge.session.bootstrap",
+        arguments: {},
+      },
+    });
+
+    expect(bridgeControl.bootstrapSession).toHaveBeenCalledOnce();
+    expect("result" in response ? response.result : undefined).toMatchObject({
+      structuredContent: {
+        ok: true,
+        bootstrapped: true,
+        session: {
+          controlMode: "bootstrap",
+          sessionState: "bootstrap_active",
         },
       },
     });
@@ -415,6 +481,29 @@ describe("createLocalMcpStdioServer", () => {
         session: {
           controlMode: "launch",
           headless: true,
+        },
+      },
+    });
+  });
+
+  it("handles bridge.session.reset_profile locally", async () => {
+    const response = await request({
+      jsonrpc: "2.0",
+      id: "2cf-reset",
+      method: "tools/call",
+      params: {
+        name: "bridge.session.reset_profile",
+        arguments: {},
+      },
+    });
+
+    expect(bridgeControl.resetProfile).toHaveBeenCalledOnce();
+    expect("result" in response ? response.result : undefined).toMatchObject({
+      structuredContent: {
+        ok: true,
+        reset: true,
+        session: {
+          lastBackupPath: "/tmp/board-profile-backup",
         },
       },
     });

--- a/packages/local-mcp/test/session.test.ts
+++ b/packages/local-mcp/test/session.test.ts
@@ -1,0 +1,131 @@
+/**
+ * This module tests auth-policy normalization and managed profile metadata helpers.
+ * It depends on the session control module so lifecycle metadata remains stable across bootstrap and reset flows.
+ */
+
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  backupAndResetProfile,
+  readSessionMetadata,
+  resolveAuthPolicy,
+  updateSessionMetadata,
+} from "../src/session.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+async function createTempProfileDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "local-mcp-session-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("resolveAuthPolicy", () => {
+  it("uses the explicit authPolicy when present", () => {
+    expect(
+      resolveAuthPolicy({
+        id: "google",
+        displayName: "Google",
+        version: "0.1.0",
+        bridgeApiVersion: "1.0.0",
+        hostPatterns: ["google.com"],
+        authPolicy: {
+          mode: "bootstrap_then_attach",
+          authProbeTool: "auth.get",
+          allowAnonymousTools: true,
+        },
+      }),
+    ).toEqual({
+      mode: "bootstrap_then_attach",
+      authProbeTool: "auth.get",
+      allowAnonymousTools: true,
+    });
+  });
+
+  it("maps legacy authProbeTool/deferBridgeUntilAuthenticated fields", () => {
+    expect(
+      resolveAuthPolicy({
+        id: "legacy",
+        displayName: "Legacy",
+        version: "0.1.0",
+        bridgeApiVersion: "1.0.0",
+        hostPatterns: ["legacy.test"],
+        authProbeTool: "auth.get",
+        deferBridgeUntilAuthenticated: true,
+      }),
+    ).toEqual({
+      mode: "bootstrap_then_attach",
+      authProbeTool: "auth.get",
+      allowAnonymousTools: true,
+    });
+  });
+});
+
+describe("session metadata helpers", () => {
+  it("clears optional fields when updateSessionMetadata receives null sentinels", async () => {
+    const profileDir = await createTempProfileDir();
+    const fallback = {
+      site: "google",
+      targetUrl: "https://gemini.google.com/",
+      authPolicy: {
+        mode: "bootstrap_then_attach",
+        authProbeTool: "auth.get",
+        allowAnonymousTools: true,
+      } as const,
+    };
+
+    await updateSessionMetadata(profileDir, fallback, {
+      sessionState: "runtime_active",
+      authState: "authenticated",
+      controlMode: "attach",
+      ownership: "managed",
+      browserUrl: "http://127.0.0.1:9222",
+      browserPid: 1234,
+    });
+
+    const updated = await updateSessionMetadata(profileDir, fallback, {
+      controlMode: "bootstrap",
+      ownership: "external",
+      browserUrl: null,
+      browserPid: null,
+    });
+
+    expect(updated.browserUrl).toBeUndefined();
+    expect(updated.browserPid).toBeUndefined();
+    expect(updated.controlMode).toBe("bootstrap");
+  });
+
+  it("backs up and recreates a profile directory", async () => {
+    const profileDir = await createTempProfileDir();
+    await writeFile(join(profileDir, "marker.txt"), "marker", "utf8");
+    const fallback = {
+      site: "google",
+      targetUrl: "https://gemini.google.com/",
+      authPolicy: {
+        mode: "bootstrap_then_attach",
+        authProbeTool: "auth.get",
+        allowAnonymousTools: true,
+      } as const,
+    };
+
+    const result = await backupAndResetProfile(profileDir, fallback);
+    const markerPath = join(result.backupPath as string, "marker.txt");
+
+    expect(result.backupPath).toBeDefined();
+    expect(await readFile(markerPath, "utf8")).toBe("marker");
+    const metadata = await readSessionMetadata(profileDir, fallback);
+    expect(metadata.sessionState).toBe("profile_missing");
+    expect(metadata.lastBackupPath).toBe(result.backupPath);
+  });
+});

--- a/packages/local-mcp/test/sites.test.ts
+++ b/packages/local-mcp/test/sites.test.ts
@@ -44,8 +44,11 @@ describe("resolveSiteSource", () => {
         bridgeApiVersion: "1.0.0",
         defaultUrl: "https://example.com",
         hostPatterns: ["example.com"],
-        authProbeTool: "auth.get",
-        deferBridgeUntilAuthenticated: true
+        authPolicy: {
+          mode: "bootstrap_then_attach",
+          authProbeTool: "auth.get",
+          allowAnonymousTools: true
+        }
       };
 
       export function createAdapter() {
@@ -64,9 +67,44 @@ describe("resolveSiteSource", () => {
 
     expect(site.source).toBe("external");
     expect(site.id).toBe("example.com");
-    expect(site.manifest.authProbeTool).toBe("auth.get");
-    expect(site.manifest.deferBridgeUntilAuthenticated).toBe(true);
+    expect(site.manifest.authPolicy).toEqual({
+      mode: "bootstrap_then_attach",
+      authProbeTool: "auth.get",
+      allowAnonymousTools: true,
+    });
     expect(typeof site.createFallbackAdapter).toBe("function");
+  });
+
+  it("still accepts legacy auth manifest fields", async () => {
+    const module = await createTempAdapterModule(`
+      export const manifest = {
+        id: "legacy.example",
+        displayName: "Legacy",
+        version: "0.1.0",
+        bridgeApiVersion: "1.0.0",
+        hostPatterns: ["legacy.example"],
+        authProbeTool: "auth.get",
+        deferBridgeUntilAuthenticated: true
+      };
+
+      export function createAdapter() {
+        return {
+          name: "adapter-legacy",
+          listTools: async () => [],
+          callTool: async () => ({ state: "authenticated" })
+        };
+      }
+    `);
+
+    const site = await resolveSiteSource({
+      adapterModule: module.path,
+    });
+
+    expect(site.manifest.authPolicy).toEqual({
+      mode: "bootstrap_then_attach",
+      authProbeTool: "auth.get",
+      allowAnonymousTools: true,
+    });
   });
 
   it("throws when both site and adapter-module are provided", async () => {

--- a/packages/local-mcp/tsconfig.json
+++ b/packages/local-mcp/tsconfig.json
@@ -8,6 +8,7 @@
       "@webmcp-bridge/core": ["packages/core/src/index.ts"],
       "@webmcp-bridge/playwright": ["packages/playwright/src/index.ts"],
       "@webmcp-bridge/local-mcp": ["packages/local-mcp/src/index.ts"],
+      "@webmcp-bridge/adapter-google": ["packages/adapter-google/src/index.ts"],
       "@webmcp-bridge/adapter-x": ["packages/adapter-x/src/index.ts"],
       "@webmcp-bridge/adapter-fixture": ["packages/adapter-fixture/src/index.ts"],
       "@webmcp-bridge/testkit": ["packages/testkit/src/index.ts"]

--- a/packages/local-mcp/vitest.config.ts
+++ b/packages/local-mcp/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       "@webmcp-bridge/core": new URL("../core/src/index.ts", import.meta.url).pathname,
       "@webmcp-bridge/playwright": new URL("../playwright/src/index.ts", import.meta.url).pathname,
       "@webmcp-bridge/local-mcp": new URL("../local-mcp/src/index.ts", import.meta.url).pathname,
+      "@webmcp-bridge/adapter-google": new URL("../adapter-google/src/index.ts", import.meta.url).pathname,
       "@webmcp-bridge/adapter-x": new URL("../adapter-x/src/index.ts", import.meta.url).pathname,
       "@webmcp-bridge/adapter-fixture": new URL("../adapter-fixture/src/index.ts", import.meta.url).pathname,
       "@webmcp-bridge/testkit": new URL("../testkit/src/index.ts", import.meta.url).pathname,

--- a/packages/playwright/src/types.ts
+++ b/packages/playwright/src/types.ts
@@ -29,6 +29,11 @@ export type AdapterManifest = {
   bridgeApiVersion: string;
   defaultUrl?: string;
   hostPatterns: string[];
+  authPolicy?: {
+    mode: "none" | "bootstrap_then_attach";
+    authProbeTool?: string;
+    allowAnonymousTools?: boolean;
+  };
   authProbeTool?: string;
   deferBridgeUntilAuthenticated?: boolean;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       '@webmcp-bridge/adapter-fixture':
         specifier: workspace:*
         version: link:../adapter-fixture
+      '@webmcp-bridge/adapter-google':
+        specifier: workspace:*
+        version: link:../adapter-google
       '@webmcp-bridge/adapter-x':
         specifier: workspace:*
         version: link:../adapter-x


### PR DESCRIPTION
## Summary
- add adapter-level auth policy support and a managed session metadata model for auth-sensitive sites
- add `bridge.session.bootstrap` and `bridge.session.reset_profile`, and expand `bridge.session.status` to report full control-plane state
- teach local-mcp to bootstrap normal browsers for manual sign-in, then attach managed Chromium sessions over CDP

## Testing
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm exec eslint docs/bridge-control-plane.md docs/cli.md packages/adapter-google/src/index.ts packages/adapter-x/src/index.ts packages/local-mcp/src/bridge.ts packages/local-mcp/src/cli.ts packages/local-mcp/src/runtime.ts packages/local-mcp/src/server.ts packages/local-mcp/src/session.ts packages/local-mcp/src/sites.ts packages/local-mcp/test/cli.test.ts packages/local-mcp/test/server.test.ts packages/local-mcp/test/session.test.ts packages/local-mcp/test/sites.test.ts packages/playwright/src/types.ts examples/board/vitest.config.ts`

## Notes
- root `pnpm lint` is still blocked by the existing untracked `tmp/article-debug.mjs` file in the worktree; this PR does not touch that file
