### PR TITLE
fix(adapter-x): close X article draft lifecycle

### DIFF
--- a/docs/manual-x-article-draft-lifecycle.md
+++ b/docs/manual-x-article-draft-lifecycle.md
@@ -12,31 +12,39 @@ This document records the manual regression flow used for issue #35:
 
 ## Preconditions
 
+- Define reusable local variables:
+  - `REPO_ROOT`: path to this repository checkout
+  - `PROFILE_DIR`: X browser profile directory with a valid login
+  - `WORK_DIR`: temp directory holding the markdown inputs for this test
+  - `COVER_IMAGE_PATH`: local image file used as the article cover
 - Local worktree is built:
   - `pnpm --filter @webmcp-bridge/adapter-x build`
   - `pnpm --filter @webmcp-bridge/local-mcp build`
-- X login is already valid in:
-  - `~/.uxc/webmcp-profile/x`
+- X login is already valid in `PROFILE_DIR`
 - Use the adapter-backed compose endpoint so X stays in `adapter-shim` mode:
 
 ```bash
-export ISSUE35_ENDPOINT="node /private/tmp/webmcp-bridge-issue35/packages/local-mcp/dist/cli.js \
-  --adapter-module /private/tmp/webmcp-bridge-issue35/packages/adapter-x/dist/index.js \
+export REPO_ROOT=/path/to/webmcp-bridge
+export PROFILE_DIR="$HOME/.uxc/webmcp-profile/x"
+export WORK_DIR=/tmp/issue35-x-flow
+export COVER_IMAGE_PATH=/path/to/cover.png
+export ISSUE35_ENDPOINT="node $REPO_ROOT/packages/local-mcp/dist/cli.js \
+  --adapter-module $REPO_ROOT/packages/adapter-x/dist/index.js \
   --url https://x.com/compose/articles \
   --headless \
   --no-auto-login-fallback \
-  --user-data-dir /Users/jolestar/.uxc/webmcp-profile/x \
+  --user-data-dir $PROFILE_DIR \
   --service-version issue35-v6"
 ```
 
 ## Test Inputs
 
 - Markdown create file:
-  - `/tmp/issue35-x-fresh2.7ZlzTZ/post.md`
+  - `$WORK_DIR/post.md`
 - Markdown update file:
-  - `/tmp/issue35-x-fresh2.7ZlzTZ/post-updated.md`
+  - `$WORK_DIR/post-updated.md`
 - Cover image:
-  - `/Users/jolestar/.uxc/daemon/blog-public-nav.png`
+  - `$COVER_IMAGE_PATH`
 
 ## Expected Behavior
 
@@ -53,10 +61,10 @@ export ISSUE35_ENDPOINT="node /private/tmp/webmcp-bridge-issue35/packages/local-
 ### 1. Create the draft
 
 ```bash
-UXC_DAEMON_EXCLUSIVE='/Users/jolestar/.uxc/webmcp-profile/x' \
+UXC_DAEMON_EXCLUSIVE="$PROFILE_DIR" \
 UXC_LINK_NAME='x-webmcp-issue35-compose-v6' \
 uxc "$ISSUE35_ENDPOINT" article.draftMarkdown \
-  '{"markdownPath":"/tmp/issue35-x-fresh2.7ZlzTZ/post.md"}'
+  "{\"markdownPath\":\"$WORK_DIR/post.md\"}"
 ```
 
 Observed result:
@@ -70,10 +78,10 @@ Observed result:
 ### 2. Add a cover image
 
 ```bash
-UXC_DAEMON_EXCLUSIVE='/Users/jolestar/.uxc/webmcp-profile/x' \
+UXC_DAEMON_EXCLUSIVE="$PROFILE_DIR" \
 UXC_LINK_NAME='x-webmcp-issue35-compose-v6' \
 uxc "$ISSUE35_ENDPOINT" article.setCoverImage \
-  '{"id":"2036666046220791808","coverImagePath":"/Users/jolestar/.uxc/daemon/blog-public-nav.png"}'
+  "{\"id\":\"2036666046220791808\",\"coverImagePath\":\"$COVER_IMAGE_PATH\"}"
 ```
 
 Observed result:
@@ -84,7 +92,7 @@ Observed result:
 ### 3. Read the draft by id
 
 ```bash
-UXC_DAEMON_EXCLUSIVE='/Users/jolestar/.uxc/webmcp-profile/x' \
+UXC_DAEMON_EXCLUSIVE="$PROFILE_DIR" \
 UXC_LINK_NAME='x-webmcp-issue35-compose-v6' \
 uxc "$ISSUE35_ENDPOINT" article.getDraft \
   '{"id":"2036666046220791808"}'
@@ -100,7 +108,7 @@ Observed result:
 ### 4. Confirm the draft appears in list results
 
 ```bash
-UXC_DAEMON_EXCLUSIVE='/Users/jolestar/.uxc/webmcp-profile/x' \
+UXC_DAEMON_EXCLUSIVE="$PROFILE_DIR" \
 UXC_LINK_NAME='x-webmcp-issue35-compose-v6' \
 uxc "$ISSUE35_ENDPOINT" article.listDrafts '{}'
 ```
@@ -114,7 +122,7 @@ Observed result:
 ### 5. Read the same draft by preview URL
 
 ```bash
-UXC_DAEMON_EXCLUSIVE='/Users/jolestar/.uxc/webmcp-profile/x' \
+UXC_DAEMON_EXCLUSIVE="$PROFILE_DIR" \
 UXC_LINK_NAME='x-webmcp-issue35-compose-v6' \
 uxc "$ISSUE35_ENDPOINT" article.get \
   '{"url":"https://x.com/i/articles/2036666046220791808/preview"}'
@@ -129,10 +137,10 @@ Observed result:
 ### 6. Update the existing draft in place
 
 ```bash
-UXC_DAEMON_EXCLUSIVE='/Users/jolestar/.uxc/webmcp-profile/x' \
+UXC_DAEMON_EXCLUSIVE="$PROFILE_DIR" \
 UXC_LINK_NAME='x-webmcp-issue35-compose-v6' \
 uxc "$ISSUE35_ENDPOINT" article.upsertDraftMarkdown \
-  '{"id":"2036666046220791808","markdownPath":"/tmp/issue35-x-fresh2.7ZlzTZ/post-updated.md"}'
+  "{\"id\":\"2036666046220791808\",\"markdownPath\":\"$WORK_DIR/post-updated.md\"}"
 ```
 
 Observed result:
@@ -144,7 +152,7 @@ Observed result:
 ### 7. Read back after update
 
 ```bash
-UXC_DAEMON_EXCLUSIVE='/Users/jolestar/.uxc/webmcp-profile/x' \
+UXC_DAEMON_EXCLUSIVE="$PROFILE_DIR" \
 UXC_LINK_NAME='x-webmcp-issue35-compose-v6' \
 uxc "$ISSUE35_ENDPOINT" article.getDraft \
   '{"id":"2036666046220791808"}'
@@ -163,7 +171,7 @@ Observed result:
 ### 8. Clean up the temporary draft
 
 ```bash
-UXC_DAEMON_EXCLUSIVE='/Users/jolestar/.uxc/webmcp-profile/x' \
+UXC_DAEMON_EXCLUSIVE="$PROFILE_DIR" \
 UXC_LINK_NAME='x-webmcp-issue35-compose-v6' \
 uxc "$ISSUE35_ENDPOINT" article.delete \
   '{"id":"2036666046220791808"}'

--- a/packages/adapter-x/src/adapter.ts
+++ b/packages/adapter-x/src/adapter.ts
@@ -4795,8 +4795,8 @@ async function listArticleDrafts(page: Page): Promise<JsonValue> {
             title: typeof articleResult.title === "string" ? normalizeInline(articleResult.title) : "",
             updatedAt: extractUpdatedAt(articleResult),
             hasCoverImage: Boolean(hasCoverImage),
-            editUrl: `https://x.com/compose/articles/edit/${restId}`,
-            previewUrl: `https://x.com/i/articles/${restId}/preview`,
+            editUrl: buildArticleEditUrl(restId),
+            previewUrl: buildArticlePreviewUrl(restId),
           });
         }
         cursor = extractNextCursor(result?.slice_info);
@@ -4813,16 +4813,29 @@ async function listArticleDrafts(page: Page): Promise<JsonValue> {
     const drafts = Array.isArray((result as Record<string, unknown>).drafts)
       ? ((result as Record<string, unknown>).drafts as unknown[])
       : [];
-    const normalizedDrafts = drafts.filter((draft): draft is ArticleDraftSummary => {
-        return Boolean(
-          draft &&
-          typeof draft === "object" &&
-          !Array.isArray(draft) &&
-          typeof (draft as Record<string, unknown>).id === "string" &&
-          typeof (draft as Record<string, unknown>).editUrl === "string" &&
-          typeof (draft as Record<string, unknown>).previewUrl === "string",
-        );
-      });
+    const normalizedDrafts = drafts
+      .map((draft): ArticleDraftSummary | undefined => {
+        if (!draft || typeof draft !== "object" || Array.isArray(draft)) {
+          return undefined;
+        }
+        const entry = draft as Record<string, unknown>;
+        if (
+          typeof entry.id !== "string" ||
+          typeof entry.editUrl !== "string" ||
+          typeof entry.previewUrl !== "string"
+        ) {
+          return undefined;
+        }
+        return {
+          id: entry.id,
+          editUrl: entry.editUrl,
+          previewUrl: entry.previewUrl,
+          title: typeof entry.title === "string" ? entry.title : "",
+          hasCoverImage: entry.hasCoverImage === true,
+          ...(typeof entry.updatedAt === "string" ? { updatedAt: entry.updatedAt } : {}),
+        };
+      })
+      .filter((draft): draft is ArticleDraftSummary => draft !== undefined);
 
     for (const draft of normalizedDrafts) {
       if (draft.hasCoverImage) {
@@ -7416,15 +7429,20 @@ export function createXAdapter(options?: CreateXAdapterOptions): SiteAdapter {
         }
         const url = typeof args.url === "string" ? args.url.trim() : "";
         const id = typeof args.id === "string" ? args.id.trim() : "";
-        const articleId = id || (url ? parseArticleIdFromUrl(url) : undefined);
-        if (!articleId && !url) {
+        if (!id && !url) {
           return errorResult("VALIDATION_ERROR", "url or id is required");
         }
-        const targetUrl = articleId ? buildArticleEditUrl(articleId) : url;
-        if (!targetUrl) {
+        let articleId = id || undefined;
+        if (!articleId && url) {
+          articleId = parseArticleIdFromUrl(url);
+          if (!articleId) {
+            return errorResult("VALIDATION_ERROR", "could not parse article id from url");
+          }
+        }
+        if (!articleId) {
           return errorResult("VALIDATION_ERROR", "url or id is required");
         }
-        return await getArticleDraft(page, targetUrl);
+        return await getArticleDraft(page, buildArticleEditUrl(articleId));
       }
 
       if (name === "article.draftMarkdown") {
@@ -7460,11 +7478,17 @@ export function createXAdapter(options?: CreateXAdapterOptions): SiteAdapter {
         }
         const explicitTitle = typeof args.title === "string" ? args.title.trim() : "";
         const coverImagePath = typeof args.coverImagePath === "string" ? args.coverImagePath.trim() : "";
-        const articleId = id || (url ? parseArticleIdFromUrl(url) : undefined);
-        const targetUrl = articleId ? buildArticleEditUrl(articleId) : "";
+        let articleId = id || undefined;
+        if (!articleId && url) {
+          articleId = parseArticleIdFromUrl(url);
+          if (!articleId) {
+            return errorResult("VALIDATION_ERROR", "url is invalid or unsupported");
+          }
+        }
+        const targetUrl = articleId ? buildArticleEditUrl(articleId) : undefined;
         return await upsertArticleDraftMarkdown(
           page,
-          targetUrl || undefined,
+          targetUrl,
           markdownPath,
           explicitTitle || undefined,
           coverImagePath || undefined,

--- a/packages/adapter-x/test/adapter.test.ts
+++ b/packages/adapter-x/test/adapter.test.ts
@@ -1607,6 +1607,23 @@ describe("createXAdapter", () => {
     });
   });
 
+  it("returns validation error for article.getDraft when url cannot be parsed", async () => {
+    const adapter = createXAdapter();
+    const { page } = createMockPage();
+
+    const result = await adapter.callTool(
+      { name: "article.getDraft", input: { url: "https://x.com/compose/articles/not-a-draft-url" } },
+      { page: page as never },
+    );
+
+    expect(result).toEqual({
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "could not parse article id from url",
+      },
+    });
+  });
+
   it("publishes one article from markdown with cover and inline images", async () => {
     const adapter = createXAdapter();
     const tempDir = await mkdtemp(join(tmpdir(), "adapter-x-article-publish-"));
@@ -1915,6 +1932,33 @@ describe("createXAdapter", () => {
     });
     expect(getArticleDraftState().html).toContain("<h2>Nested title</h2>");
     expect(getArticleDraftState().html).not.toContain("<h1>Same title</h1>");
+  });
+
+  it("returns validation error for article.upsertDraftMarkdown when url is invalid", async () => {
+    const adapter = createXAdapter();
+    const tempDir = await mkdtemp(join(tmpdir(), "adapter-x-article-upsert-invalid-url-"));
+    tempDirs.add(tempDir);
+    const markdownPath = join(tempDir, "post.md");
+    await writeFile(markdownPath, "# Same title\n\nUpdated body.\n");
+    const { page } = createMockPage();
+
+    const result = await adapter.callTool(
+      {
+        name: "article.upsertDraftMarkdown",
+        input: {
+          url: "https://x.com/compose/articles/not-a-draft-url",
+          markdownPath,
+        },
+      },
+      { page: page as never },
+    );
+
+    expect(result).toEqual({
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "url is invalid or unsupported",
+      },
+    });
   });
 
   it("supports dryRun for article.delete", async () => {


### PR DESCRIPTION
Fixes #35

## Summary
- add draft lifecycle tools for X articles: list, get, and upsert existing drafts
- normalize title/H1 handling so X article titles do not duplicate the first markdown H1
- preserve draft identifiers and preview/edit URLs across create and update flows
- confirm cover-image application and make draft/preview readback stable
- add a manual regression document for the end-to-end X draft workflow

## Verification
- pnpm --filter @webmcp-bridge/adapter-x typecheck
- pnpm --filter @webmcp-bridge/adapter-x test -- test/adapter.test.ts
- pnpm --filter @webmcp-bridge/adapter-x build
- manual X flow in real profile: create draft, set cover image, read by id, list drafts, read by preview URL, upsert body, reread, delete temporary drafts
