### PR TITLE
fix(adapter-weibo): harden weibo article cover and formatting

### DIFF
--- a/packages/adapter-weibo/src/adapter.ts
+++ b/packages/adapter-weibo/src/adapter.ts
@@ -1046,7 +1046,7 @@ function convertMarkdownInlineToWeiboHtml(value: string): string {
         return text;
       }
       const normalizedHref = href.replace(/^https?:\/\//i, "");
-      const showVisibleHref = href.startsWith("mailto:") ? false : textRaw.trim() !== hrefRaw.trim() || textRaw.trim() !== normalizedHref;
+      const showVisibleHref = href.startsWith("mailto:") ? false : textRaw.trim() !== hrefRaw.trim() && textRaw.trim() !== normalizedHref;
       return reserve(
         showVisibleHref
           ? `<a href="${escapeHtml(href)}">${text}</a><span>（${escapeHtml(normalizedHref)}）</span>`
@@ -1167,6 +1167,39 @@ function convertMarkdownToWeiboArticleHtml(markdown: string): string {
   return blocks.join("<p><br></p>");
 }
 
+function convertMarkdownLineToWeiboPlainText(line: string): string {
+  return line
+    .replace(/^#{1,6}\s+/, "")
+    .replace(/^[-*+]\s+/, "")
+    .replace(/^\d+\.\s+/, "")
+    .replace(/^>\s+/, "")
+    .replace(/!\[([^\]]*)\]\(([^)]+)\)/g, "$1")
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function convertMarkdownToWeiboPlainText(markdown: string): string {
+  const output: string[] = [];
+  let insideFence = false;
+  for (const rawLine of markdown.replace(/\r\n/g, "\n").split("\n")) {
+    const trimmed = rawLine.trim();
+    if (!trimmed) {
+      output.push("");
+      continue;
+    }
+    if (/^```/.test(trimmed)) {
+      insideFence = !insideFence;
+      continue;
+    }
+    output.push(insideFence ? trimmed : convertMarkdownLineToWeiboPlainText(trimmed));
+  }
+  return output.join("\n").trim();
+}
+
 function extractMarkdownLead(markdown: string): string | undefined {
   for (const line of markdown.replace(/\r\n/g, "\n").split("\n")) {
     const trimmed = line.trim();
@@ -1204,7 +1237,7 @@ function prepareArticleMarkdown(markdown: string, markdownPath: string, explicit
   return {
     markdown: prepared,
     html: convertMarkdownToWeiboArticleHtml(prepared),
-    plainText: prepared,
+    plainText: convertMarkdownToWeiboPlainText(prepared),
     ...(lead ? { lead } : {}),
   };
 }

--- a/packages/adapter-weibo/test/adapter.test.ts
+++ b/packages/adapter-weibo/test/adapter.test.ts
@@ -48,6 +48,9 @@ function createMockPage(options?: {
     if (!arg && source.includes(".cover-preview .cover-img")) {
       return coverPreviewSrc;
     }
+    if (!arg && source.includes("textarea[placeholder*='标题']") && source.includes("[contenteditable='true']")) {
+      return true;
+    }
     if (!arg && source.includes("正文图片") && source.includes("图片库") && source.includes("取消")) {
       return coverDialogVisible;
     }
@@ -205,9 +208,6 @@ function createMockPage(options?: {
       };
     }
     if (arg && typeof arg === "object" && !Array.isArray(arg) && "op" in arg && arg.op === "article_publish_ready") {
-      return true;
-    }
-    if (arg === undefined) {
       return true;
     }
     return undefined;
@@ -398,9 +398,6 @@ function createMockPage(options?: {
       }
       if (arg && typeof arg === "object" && !Array.isArray(arg) && "op" in arg && arg.op === "extract_ai_search") {
         return options?.aiSummary;
-      }
-      if (arg === undefined) {
-        return true;
       }
       return undefined;
     }),


### PR DESCRIPTION
## Summary
- fix the real Weibo article cover flow by following the full library -> cropper -> confirm chain
- make article body insertion prefer rich paste but fall back when Weibo downgrades clipboard HTML to raw markdown
- tune Weibo markdown conversion for paragraphs, line breaks, list rendering, and visible link targets

## Validation
- pnpm --filter @webmcp-bridge/adapter-weibo typecheck
- pnpm --filter @webmcp-bridge/adapter-weibo exec vitest run
- pnpm --filter @webmcp-bridge/adapter-weibo build
- real account dry-run: `weibo-webmcp-cli article.publishMarkdown '{"markdownPath":"/tmp/weibo-article-preview.md","coverImagePath":"/Users/jolestar/opensource/src/github.com/holon-run/webmcp-bridge/docs/images/bridge-architecture.png","dryRun":true}'`
  - confirmed `hasCoverImage: true`
  - confirmed article body no longer falls back to raw markdown text in the editor
