### PR TITLE
fix(local-mcp): add bridge recovery instructions

### DIFF
--- a/packages/local-mcp/src/mcp-types.ts
+++ b/packages/local-mcp/src/mcp-types.ts
@@ -60,6 +60,7 @@ export type McpInitializeResult = {
     name: string;
     version: string;
   };
+  instructions?: string;
 };
 
 export type McpResourceDefinition = {

--- a/packages/local-mcp/src/server.ts
+++ b/packages/local-mcp/src/server.ts
@@ -80,6 +80,14 @@ export type LocalMcpStdioServer = {
   close: () => Promise<void>;
 };
 
+const SERVICE_INSTRUCTIONS = [
+  "If help only shows bridge.* tools, the site session is not attached to page tools yet.",
+  "Call bridge.session.status first.",
+  "If the session needs sign-in, call bridge.session.bootstrap and finish login in the browser.",
+  "If you already have a signed-in browser or managed profile, call bridge.session.attach.",
+  "After attach succeeds, run help again to see site tools.",
+].join(" ");
+
 class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
   private static readonly BRIDGE_CLOSE_DELAY_MS = 100;
   private readonly server: Server;
@@ -111,6 +119,7 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
             subscribe: true,
           },
         },
+        instructions: SERVICE_INSTRUCTIONS,
       },
     );
 

--- a/packages/local-mcp/test/server.test.ts
+++ b/packages/local-mcp/test/server.test.ts
@@ -224,6 +224,7 @@ describe("createLocalMcpStdioServer", () => {
       serverInfo: {
         name: "webmcp-bridge-local-mcp",
       },
+      instructions: expect.stringContaining("If help only shows bridge.* tools"),
       capabilities: {
         tools: {
           listChanged: true,


### PR DESCRIPTION
## Summary
- add static MCP service instructions that explain how to recover from bridge-only sessions
- keep bridge tool descriptions simple so tools/list output stays stable
- cover initialize instructions in local-mcp server tests

## Verification
- pnpm --filter @webmcp-bridge/local-mcp typecheck
- pnpm --filter @webmcp-bridge/local-mcp test -- test/server.test.ts