### PR TITLE
fix(local-mcp): make navigation timeouts configurable

### DIFF
--- a/packages/local-mcp/src/bridge.ts
+++ b/packages/local-mcp/src/bridge.ts
@@ -57,6 +57,7 @@ export type StartLocalMcpBridgeOptions = {
   preferredPresentationMode?: BridgePresentationMode;
   userDataDir?: string;
   preferNative?: boolean;
+  navigationTimeoutMs?: number;
   serviceVersion: string;
   autoLoginFallback?: boolean;
   input?: Readable;
@@ -86,6 +87,7 @@ type RuntimeStartOptions = {
   userDataDir?: string;
   preferNative?: boolean;
   autoLoginFallback?: boolean;
+  navigationTimeoutMs?: number;
 };
 
 async function resolveSiteDefinitionFromBridgeOptions(options: StartLocalMcpBridgeOptions): Promise<SiteDefinition> {
@@ -141,6 +143,9 @@ function buildRuntimeStartOptions(
   }
   if (baseOptions.preferNative !== undefined) {
     nextOptions.preferNative = baseOptions.preferNative;
+  }
+  if (baseOptions.navigationTimeoutMs !== undefined) {
+    nextOptions.navigationTimeoutMs = baseOptions.navigationTimeoutMs;
   }
   if (baseOptions.autoLoginFallback !== undefined) {
     nextOptions.autoLoginFallback = baseOptions.autoLoginFallback;

--- a/packages/local-mcp/src/cli.ts
+++ b/packages/local-mcp/src/cli.ts
@@ -47,6 +47,7 @@ Optional:
   --auto-login-fallback        Auto-switch to headed mode when auth is required in headless mode (default: true)
   --no-auto-login-fallback     Disable auto-switch login fallback
   --user-data-dir <path>       Playwright persistent profile directory
+  --navigation-timeout-ms <n>  Override page navigation timeout in milliseconds
   --service-version <value>    MCP server version string (default: ${DEFAULT_SERVICE_VERSION})
   --help                       Show this help message
 `;
@@ -62,6 +63,7 @@ export type LocalMcpCliOptions = {
   preferredPresentationMode: BridgePresentationMode;
   autoLoginFallback: boolean;
   userDataDir?: string;
+  navigationTimeoutMs?: number;
   serviceVersion: string;
 };
 
@@ -71,6 +73,14 @@ function parseFlagValue(args: string[], index: number, flag: string): string {
     throw new Error(`missing value for ${flag}`);
   }
   return value;
+}
+
+function parsePositiveInteger(value: string, flag: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`invalid value for ${flag}: ${value}`);
+  }
+  return parsed;
 }
 
 export function parseCliArgs(args: string[]): LocalMcpCliOptions {
@@ -84,6 +94,7 @@ export function parseCliArgs(args: string[]): LocalMcpCliOptions {
   let preferredPresentationMode: BridgePresentationMode = "headed";
   let autoLoginFallback = true;
   let userDataDir: string | undefined;
+  let navigationTimeoutMs: number | undefined;
   let serviceVersion = DEFAULT_SERVICE_VERSION;
 
   for (let i = 0; i < args.length; i += 1) {
@@ -164,6 +175,15 @@ export function parseCliArgs(args: string[]): LocalMcpCliOptions {
       continue;
     }
 
+    if (arg === "--navigation-timeout-ms") {
+      navigationTimeoutMs = parsePositiveInteger(
+        parseFlagValue(args, i, "--navigation-timeout-ms"),
+        "--navigation-timeout-ms",
+      );
+      i += 1;
+      continue;
+    }
+
     if (arg === "--auto-login-fallback") {
       autoLoginFallback = true;
       continue;
@@ -221,6 +241,14 @@ export function parseCliArgs(args: string[]): LocalMcpCliOptions {
   }
   if (userDataDir !== undefined) {
     options.userDataDir = userDataDir;
+  }
+  if (navigationTimeoutMs !== undefined) {
+    options.navigationTimeoutMs = navigationTimeoutMs;
+  } else {
+    const envValue = process.env.WEBMCP_NAVIGATION_TIMEOUT_MS?.trim();
+    if (envValue) {
+      options.navigationTimeoutMs = parsePositiveInteger(envValue, "WEBMCP_NAVIGATION_TIMEOUT_MS");
+    }
   }
 
   return options;

--- a/packages/local-mcp/src/cli.ts
+++ b/packages/local-mcp/src/cli.ts
@@ -76,8 +76,11 @@ function parseFlagValue(args: string[], index: number, flag: string): string {
 }
 
 function parsePositiveInteger(value: string, flag: string): number {
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`invalid value for ${flag}: ${value}`);
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
     throw new Error(`invalid value for ${flag}: ${value}`);
   }
   return parsed;

--- a/packages/local-mcp/src/runtime.ts
+++ b/packages/local-mcp/src/runtime.ts
@@ -786,19 +786,14 @@ export async function startLocalMcpRuntime(options: LocalMcpRuntimeOptions): Pro
       site.manifest.hostPatterns,
     );
     if (recoveryNavigationUrl) {
+      const recoveryTimeoutMs = options.navigationTimeoutMs ?? resolveNavigationTimeoutMs(recoveryNavigationUrl);
       try {
-        const recoveryTimeoutMs = options.navigationTimeoutMs ?? resolveNavigationTimeoutMs(recoveryNavigationUrl);
         await currentPage.goto(recoveryNavigationUrl, {
           waitUntil: "domcontentloaded",
           timeout: recoveryTimeoutMs,
         });
       } catch (error) {
-        throw mapNavigationError(
-          error,
-          recoveryNavigationUrl,
-          "goto",
-          options.navigationTimeoutMs ?? resolveNavigationTimeoutMs(recoveryNavigationUrl),
-        );
+        throw mapNavigationError(error, recoveryNavigationUrl, "goto", recoveryTimeoutMs);
       }
     }
     await initializePageSession(false);

--- a/packages/local-mcp/src/runtime.ts
+++ b/packages/local-mcp/src/runtime.ts
@@ -29,7 +29,8 @@ import type { LocalMcpGateway } from "./server.js";
 import { resolveAuthPolicy, type BridgePresentationMode } from "./session.js";
 import type { SiteDefinition } from "./sites.js";
 
-const NAVIGATION_TIMEOUT_MS = 5_000;
+const LOCAL_NAVIGATION_TIMEOUT_MS = 5_000;
+const REMOTE_NAVIGATION_TIMEOUT_MS = 30_000;
 const LAUNCH_RETRY_DELAY_MS = 750;
 const MAX_LAUNCH_ATTEMPTS = 2;
 const GATEWAY_RECOVERABLE_ERROR_SNIPPETS = [
@@ -66,6 +67,7 @@ export type LocalMcpRuntimeOptions = {
   preferredPresentationMode?: BridgePresentationMode;
   userDataDir?: string;
   preferNative?: boolean;
+  navigationTimeoutMs?: number;
 };
 
 export type LocalMcpRuntime = {
@@ -448,7 +450,12 @@ export function resolveBridgeRuntimeMode(
   return gatewayMode;
 }
 
-export function mapNavigationError(error: unknown, targetUrl: string, phase: "goto" | "reload"): Error {
+export function mapNavigationError(
+  error: unknown,
+  targetUrl: string,
+  phase: "goto" | "reload",
+  timeoutMs?: number,
+): Error {
   const message = extractErrorMessage(error);
   const normalizedPhase = phase === "goto" ? "open" : "reload";
   if (
@@ -461,9 +468,35 @@ export function mapNavigationError(error: unknown, targetUrl: string, phase: "go
     return new Error(`TARGET_UNREACHABLE: failed to ${normalizedPhase} ${targetUrl}: ${message}`);
   }
   if (message.toLowerCase().includes("timeout")) {
-    return new Error(`NAVIGATION_TIMEOUT: timed out trying to ${normalizedPhase} ${targetUrl}: ${message}`);
+    const timeoutHint =
+      timeoutMs !== undefined
+        ? ` current timeout=${timeoutMs}ms; increase it with --navigation-timeout-ms or WEBMCP_NAVIGATION_TIMEOUT_MS.`
+        : " increase it with --navigation-timeout-ms or WEBMCP_NAVIGATION_TIMEOUT_MS.";
+    return new Error(
+      `NAVIGATION_TIMEOUT: timed out trying to ${normalizedPhase} ${targetUrl}:${timeoutHint} ${message}`,
+    );
   }
   return new Error(`NAVIGATION_FAILED: failed to ${normalizedPhase} ${targetUrl}: ${message}`);
+}
+
+export function resolveNavigationTimeoutMs(targetUrl: string): number {
+  try {
+    const parsed = new URL(targetUrl);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return LOCAL_NAVIGATION_TIMEOUT_MS;
+    }
+    if (
+      parsed.hostname === "localhost" ||
+      parsed.hostname === "127.0.0.1" ||
+      parsed.hostname === "::1"
+    ) {
+      return LOCAL_NAVIGATION_TIMEOUT_MS;
+    }
+  } catch {
+    // Non-HTTP targets should use the conservative local timeout.
+    return LOCAL_NAVIGATION_TIMEOUT_MS;
+  }
+  return REMOTE_NAVIGATION_TIMEOUT_MS;
 }
 
 async function waitForPolyfillTools(
@@ -506,6 +539,7 @@ export async function startLocalMcpRuntime(options: LocalMcpRuntimeOptions): Pro
   }
   const browserType = resolveBrowserType(browserEngine);
   const targetUrl = resolveTargetUrl(options.url, site.manifest.defaultUrl);
+  const navigationTimeoutMs = options.navigationTimeoutMs ?? resolveNavigationTimeoutMs(targetUrl);
   const controlMode = browserUrl ? "attach" : "launch";
   if (!isUrlAllowed(targetUrl, site.manifest.hostPatterns)) {
     throw new Error("URL_NOT_ALLOWED: target url host is not allowed by adapter hostPatterns");
@@ -687,10 +721,10 @@ export async function startLocalMcpRuntime(options: LocalMcpRuntimeOptions): Pro
       try {
         await pageForEvents.goto(targetUrl, {
           waitUntil: "domcontentloaded",
-          timeout: NAVIGATION_TIMEOUT_MS,
+          timeout: navigationTimeoutMs,
         });
       } catch (error) {
-        throw mapNavigationError(error, targetUrl, "goto");
+        throw mapNavigationError(error, targetUrl, "goto", navigationTimeoutMs);
       }
     }
 
@@ -714,10 +748,10 @@ export async function startLocalMcpRuntime(options: LocalMcpRuntimeOptions): Pro
       try {
         await pageForEvents.reload({
           waitUntil: "domcontentloaded",
-          timeout: NAVIGATION_TIMEOUT_MS,
+          timeout: navigationTimeoutMs,
         });
       } catch (error) {
-        throw mapNavigationError(error, targetUrl, "reload");
+        throw mapNavigationError(error, targetUrl, "reload", navigationTimeoutMs);
       }
       if (shouldWaitForPolyfillVisibility) {
         await waitForPolyfillTools(currentGatewaySession).catch(() => {
@@ -753,12 +787,18 @@ export async function startLocalMcpRuntime(options: LocalMcpRuntimeOptions): Pro
     );
     if (recoveryNavigationUrl) {
       try {
+        const recoveryTimeoutMs = options.navigationTimeoutMs ?? resolveNavigationTimeoutMs(recoveryNavigationUrl);
         await currentPage.goto(recoveryNavigationUrl, {
           waitUntil: "domcontentloaded",
-          timeout: NAVIGATION_TIMEOUT_MS,
+          timeout: recoveryTimeoutMs,
         });
       } catch (error) {
-        throw mapNavigationError(error, recoveryNavigationUrl, "goto");
+        throw mapNavigationError(
+          error,
+          recoveryNavigationUrl,
+          "goto",
+          options.navigationTimeoutMs ?? resolveNavigationTimeoutMs(recoveryNavigationUrl),
+        );
       }
     }
     await initializePageSession(false);

--- a/packages/local-mcp/test/cli.test.ts
+++ b/packages/local-mcp/test/cli.test.ts
@@ -3,7 +3,7 @@
  * It depends on CLI and site modules to validate deterministic startup option handling.
  */
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -18,6 +18,10 @@ const packageVersion = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
 };
 
 describe("parseCliArgs", () => {
+  afterEach(() => {
+    delete process.env.WEBMCP_NAVIGATION_TIMEOUT_MS;
+  });
+
   it("parses built-in site with optional flags", () => {
     const parsed = parseCliArgs([
       "--site",
@@ -39,6 +43,29 @@ describe("parseCliArgs", () => {
       autoLoginFallback: true,
       serviceVersion: "0.2.0",
     });
+  });
+
+  it("parses a navigation timeout override", () => {
+    const parsed = parseCliArgs(["--site", "x", "--navigation-timeout-ms", "20000"]);
+    expect(parsed.navigationTimeoutMs).toBe(20000);
+  });
+
+  it("reads navigation timeout from the environment", () => {
+    process.env.WEBMCP_NAVIGATION_TIMEOUT_MS = "25000";
+    const parsed = parseCliArgs(["--site", "x"]);
+    expect(parsed.navigationTimeoutMs).toBe(25000);
+  });
+
+  it("lets the CLI flag override the environment timeout", () => {
+    process.env.WEBMCP_NAVIGATION_TIMEOUT_MS = "25000";
+    const parsed = parseCliArgs(["--site", "x", "--navigation-timeout-ms", "18000"]);
+    expect(parsed.navigationTimeoutMs).toBe(18000);
+  });
+
+  it("rejects invalid navigation timeout values", () => {
+    expect(() => parseCliArgs(["--site", "x", "--navigation-timeout-ms", "0"])).toThrow(
+      "invalid value for --navigation-timeout-ms: 0",
+    );
   });
 
   it("parses external adapter module", () => {

--- a/packages/local-mcp/test/cli.test.ts
+++ b/packages/local-mcp/test/cli.test.ts
@@ -68,6 +68,12 @@ describe("parseCliArgs", () => {
     );
   });
 
+  it("rejects partially numeric navigation timeout values", () => {
+    expect(() => parseCliArgs(["--site", "x", "--navigation-timeout-ms", "25000ms"])).toThrow(
+      "invalid value for --navigation-timeout-ms: 25000ms",
+    );
+  });
+
   it("parses external adapter module", () => {
     const parsed = parseCliArgs(["--adapter-module", "@example/webmcp-adapter"]);
     expect(parsed.adapterModule).toBe("@example/webmcp-adapter");

--- a/packages/local-mcp/test/runtime.test.ts
+++ b/packages/local-mcp/test/runtime.test.ts
@@ -9,6 +9,7 @@ import {
   isRecoverableGatewayError,
   isUrlAllowed,
   mapNavigationError,
+  resolveNavigationTimeoutMs,
   resolveBridgeRuntimeMode,
   resolveCdpConnectUrl,
   resolveCdpVersionEndpoint,
@@ -78,9 +79,28 @@ describe("mapNavigationError", () => {
       new Error("page.goto: Timeout 5000ms exceeded."),
       "http://127.0.0.1:4173",
       "goto",
+      5000,
     );
 
     expect(error.message).toContain("NAVIGATION_TIMEOUT");
+    expect(error.message).toContain("--navigation-timeout-ms");
+    expect(error.message).toContain("current timeout=5000ms");
+  });
+});
+
+describe("resolveNavigationTimeoutMs", () => {
+  it("keeps localhost targets on the fast-fail timeout", () => {
+    expect(resolveNavigationTimeoutMs("http://127.0.0.1:4173")).toBe(5000);
+    expect(resolveNavigationTimeoutMs("http://localhost:4173")).toBe(5000);
+  });
+
+  it("gives remote https targets more time to cold-start", () => {
+    expect(resolveNavigationTimeoutMs("https://x.com/home")).toBe(30000);
+    expect(resolveNavigationTimeoutMs("https://gemini.google.com/app")).toBe(30000);
+  });
+
+  it("falls back to the local timeout for non-url targets", () => {
+    expect(resolveNavigationTimeoutMs("about:blank")).toBe(5000);
   });
 });
 


### PR DESCRIPTION
## Summary
- make local-mcp navigation timeouts configurable through `--navigation-timeout-ms` and `WEBMCP_NAVIGATION_TIMEOUT_MS`
- raise the default timeout for remote sites while keeping localhost fast-fail behavior
- improve `NAVIGATION_TIMEOUT` errors so they include the active timeout and remediation hints

## Root cause
Cold-starting remote sites like `https://x.com/home` can exceed the previous fixed 5s Playwright navigation timeout, causing the stdio child to exit before MCP initialize completed.

## Testing
- pnpm --filter @webmcp-bridge/local-mcp typecheck
- pnpm exec vitest run packages/local-mcp/test/cli.test.ts packages/local-mcp/test/runtime.test.ts packages/local-mcp/test/server.test.ts packages/local-mcp/test/bridge.test.ts
