### PR TITLE
feat: add local-mcp lifecycle contract notifications

### DIFF
--- a/packages/agent-browser-core/src/controller.ts
+++ b/packages/agent-browser-core/src/controller.ts
@@ -74,6 +74,7 @@ export type BrowserSessionController<
 > = {
   getState: () => BrowserSessionStatus;
   getRuntime: () => TRuntime | undefined;
+  onStateChanged: (listener: () => void) => () => void;
   onResourceUpdated: (listener: (uri: string) => void) => () => void;
   onToolsetMayHaveChanged: (listener: () => void) => () => void;
   openWindow: () => Promise<"focused" | "opened">;
@@ -148,7 +149,9 @@ export async function startBrowserSessionController<
   let unsubscribeRuntimeResourceUpdates: (() => void) | undefined;
   let ownerSessionGeneration = 0;
   const resourceUpdatedListeners = new Set<(uri: string) => void>();
+  const stateChangedListeners = new Set<() => void>();
   const toolsetChangedListeners = new Set<() => void>();
+  let lastStateSignature: string | undefined;
 
   const metadataFallback = options.profilePath
     ? {
@@ -178,6 +181,21 @@ export async function startBrowserSessionController<
     return state;
   };
 
+  const notifyStateChanged = (): void => {
+    const signature = JSON.stringify(refreshStatus());
+    if (lastStateSignature === signature) {
+      return;
+    }
+    lastStateSignature = signature;
+    for (const listener of stateChangedListeners) {
+      try {
+        listener();
+      } catch (error) {
+        options.onError?.(error);
+      }
+    }
+  };
+
   const syncFromMetadata = (nextMetadata: SessionMetadata): void => {
     metadata = nextMetadata;
     controlMode = nextMetadata.controlMode;
@@ -193,6 +211,7 @@ export async function startBrowserSessionController<
       runtimeMode = "control-only";
       presentationMode = nextMetadata.controlMode === "bootstrap" ? "headed" : nextMetadata.presentationMode;
     }
+    notifyStateChanged();
   };
 
   const writeMetadata = async (patch: SessionMetadataPatch): Promise<void> => {
@@ -282,6 +301,7 @@ export async function startBrowserSessionController<
     }
     browserUrl = undefined;
     browserPid = undefined;
+    notifyStateChanged();
   };
 
   const bindRuntime = (nextRuntime: TRuntime, nextOwnership: BridgeSessionOwnership): void => {
@@ -305,6 +325,7 @@ export async function startBrowserSessionController<
       }
       notifyCloseRequested();
     });
+    notifyStateChanged();
   };
 
   const clearRuntime = (): void => {
@@ -313,6 +334,7 @@ export async function startBrowserSessionController<
     unsubscribeRuntimeResourceUpdates?.();
     unsubscribeRuntimeResourceUpdates = undefined;
     notifyToolsetMayHaveChanged();
+    notifyStateChanged();
   };
 
   const closeRuntime = async (): Promise<void> => {
@@ -405,6 +427,7 @@ export async function startBrowserSessionController<
     }
     await writeMetadata(bootstrapPatch);
     notifyToolsetMayHaveChanged();
+    notifyStateChanged();
     return refreshStatus();
   };
 
@@ -429,6 +452,7 @@ export async function startBrowserSessionController<
     preferredPresentationMode = "headed";
     await writeMetadata(bootstrapPatch);
     notifyToolsetMayHaveChanged();
+    notifyStateChanged();
     return refreshStatus();
   };
 
@@ -458,6 +482,7 @@ export async function startBrowserSessionController<
       runtimePatch.browserPid = nextBrowserPid ?? null;
       await writeMetadata(runtimePatch);
     }
+    notifyStateChanged();
     return refreshStatus();
   };
 
@@ -627,6 +652,7 @@ export async function startBrowserSessionController<
           preferredPresentationMode,
         });
       }
+      notifyStateChanged();
       return refreshStatus();
     }
     if (controlMode === "attach") {
@@ -751,6 +777,12 @@ export async function startBrowserSessionController<
   const controller: BrowserSessionController<TRuntime> = {
     getState: refreshStatus,
     getRuntime: () => runtime,
+    onStateChanged: (listener) => {
+      stateChangedListeners.add(listener);
+      return () => {
+        stateChangedListeners.delete(listener);
+      };
+    },
     onResourceUpdated: (listener) => {
       resourceUpdatedListeners.add(listener);
       return () => {

--- a/packages/local-mcp/src/bridge.ts
+++ b/packages/local-mcp/src/bridge.ts
@@ -200,7 +200,17 @@ export async function startLocalMcpBridge(options: StartLocalMcpBridgeOptions): 
   let server: LocalMcpStdioServer | undefined;
   let closeRequested = false;
   let closeResources: () => Promise<void> = async () => {};
+  const lifecycleListeners = new Set<() => void>();
   const toolsetListeners = new Set<() => void>();
+  const notifyLifecycleMayHaveChanged = (): void => {
+    for (const listener of lifecycleListeners) {
+      try {
+        listener();
+      } catch (error) {
+        options.onError?.(error);
+      }
+    }
+  };
   const notifyToolsetMayHaveChanged = (): void => {
     for (const listener of toolsetListeners) {
       try {
@@ -249,6 +259,10 @@ export async function startLocalMcpBridge(options: StartLocalMcpBridgeOptions): 
   const unsubscribeControllerToolset = controller.onToolsetMayHaveChanged(() => {
     notifyToolsetMayHaveChanged();
   });
+  const unsubscribeControllerState = controller.onStateChanged(() => {
+    lastState = toLocalBridgeState(controller.getState());
+    notifyLifecycleMayHaveChanged();
+  });
   let closed = false;
   let lastState = toLocalBridgeState(controller.getState());
 
@@ -259,6 +273,7 @@ export async function startLocalMcpBridge(options: StartLocalMcpBridgeOptions): 
     closed = true;
     lastState = toLocalBridgeState(controller.getState());
     unsubscribeControllerToolset();
+    unsubscribeControllerState();
     const activeServer = server;
     server = undefined;
     const results = await Promise.allSettled([activeServer?.close(), controller.close()]);
@@ -394,6 +409,12 @@ export async function startLocalMcpBridge(options: StartLocalMcpBridgeOptions): 
         },
       },
       serviceVersion: options.serviceVersion,
+      onLifecycleMayHaveChanged: (listener) => {
+        lifecycleListeners.add(listener);
+        return () => {
+          lifecycleListeners.delete(listener);
+        };
+      },
       onToolsetMayHaveChanged: (listener) => {
         toolsetListeners.add(listener);
         return () => {

--- a/packages/local-mcp/src/mcp-types.ts
+++ b/packages/local-mcp/src/mcp-types.ts
@@ -63,15 +63,15 @@ export type McpInitializeResult = {
   instructions?: string;
 };
 
-export type McpCanReapResult = {
-  can_reap: boolean;
-  reason?: string;
+export type McpLifecycleContractResult = {
+  reap_policy: "safe_idle_reap" | "stateful";
+};
+
+export type McpLifecycleSnapshot = {
+  auto_reap_allowed: boolean;
+  retention_reason?: string | null;
   retry_after_secs?: number;
-  state?: {
-    interactive?: boolean;
-    owns_external_resource?: boolean;
-    waiting_for_human?: boolean;
-  };
+  updated_at_unix: number;
 };
 
 export type McpResourceDefinition = {

--- a/packages/local-mcp/src/server.ts
+++ b/packages/local-mcp/src/server.ts
@@ -16,10 +16,17 @@ import {
   UnsubscribeRequestSchema,
   type CallToolResult,
 } from "@modelcontextprotocol/sdk/types.js";
-import type { WebMcpResourceDefinition, WebMcpToolDefinition } from "@webmcp-bridge/playwright";
+import type {
+  WebMcpResourceDefinition,
+  WebMcpToolDefinition,
+} from "@webmcp-bridge/playwright";
 import type { Readable, Writable } from "node:stream";
 import { z } from "zod";
-import type { McpCanReapResult, McpToolDefinition } from "./mcp-types.js";
+import type {
+  McpLifecycleContractResult,
+  McpLifecycleSnapshot,
+  McpToolDefinition,
+} from "./mcp-types.js";
 import type {
   ExportOverlayResult,
   InstallOverlayOptions,
@@ -38,7 +45,10 @@ import type {
 
 export type LocalMcpGateway = {
   listTools: () => Promise<ReadonlyArray<WebMcpToolDefinition>>;
-  callTool: (name: string, input: Record<string, unknown>) => Promise<JsonValue>;
+  callTool: (
+    name: string,
+    input: Record<string, unknown>,
+  ) => Promise<JsonValue>;
   listResources: () => Promise<ReadonlyArray<WebMcpResourceDefinition>>;
   readResource: (uri: string) => Promise<JsonValue>;
   onResourceUpdated: (listener: (uri: string) => void) => () => void;
@@ -49,7 +59,12 @@ export type LocalBridgeState = {
   targetUrl: string;
   controlMode: BridgeControlMode;
   browserUrl?: string;
-  mode: "native" | "polyfill" | "adapter-shim" | "overlay-bootstrap" | "control-only";
+  mode:
+    | "native"
+    | "polyfill"
+    | "adapter-shim"
+    | "overlay-bootstrap"
+    | "control-only";
   presentationMode: BridgePresentationMode;
   preferredPresentationMode: BridgePresentationMode;
   authPolicyMode: "none" | "bootstrap_then_attach";
@@ -79,7 +94,9 @@ export type LocalBridgeControl = {
   deleteOverlay: (id: string) => Promise<void>;
   exportOverlay: (id: string) => Promise<ExportOverlayResult>;
   getPresentationMode: () => BridgePresentationMode;
-  setPresentationMode: (options: LocalBridgePresentationModeSetOptions) => Promise<LocalBridgeState>;
+  setPresentationMode: (
+    options: LocalBridgePresentationModeSetOptions,
+  ) => Promise<LocalBridgeState>;
   resetProfile: () => Promise<LocalBridgeState>;
   closeBridge: () => Promise<void>;
 };
@@ -107,16 +124,11 @@ const SERVICE_INSTRUCTIONS = [
   "If the page has no native WebMCP or adapter tools yet, use bridge.debug.eval and bridge.overlay.* to bootstrap draft tools.",
   "After attach succeeds, run help again to see site tools.",
 ].join(" ");
-const CAN_REAP_RETRY_AFTER_SECS = 30;
+const LIFECYCLE_RETRY_AFTER_SECS = 30;
 
-const UxcCanReapRequestSchema = RequestSchema.extend({
-  method: z.literal("uxc/can_reap"),
-  params: z
-    .object({
-      idle_for_secs: z.number().int().nonnegative(),
-      idle_ttl_secs: z.number().int().nonnegative(),
-    })
-    .optional(),
+const UxcLifecycleContractRequestSchema = RequestSchema.extend({
+  method: z.literal("uxc/lifecycle_contract"),
+  params: z.object({}).passthrough().optional(),
 });
 
 type OverlayToolInput = {
@@ -142,6 +154,7 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
   private readonly unsubscribeResourceUpdates: () => void;
   private readonly unsubscribeToolsetChanges: () => void;
   private toolsetNotification = Promise.resolve();
+  private lastLifecycleSignature: string | undefined;
 
   constructor(options: LocalMcpStdioServerOptions) {
     this.onError = options.onError;
@@ -167,10 +180,15 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
         instructions: SERVICE_INSTRUCTIONS,
       },
     );
+    this.server.oninitialized = () => {
+      void this.notifyLifecycleSnapshot(options.bridgeControl.getState(), true);
+    };
 
-    this.unsubscribeResourceUpdates = options.gateway.onResourceUpdated((uri) => {
-      void this.notifyResourceUpdated(uri);
-    });
+    this.unsubscribeResourceUpdates = options.gateway.onResourceUpdated(
+      (uri) => {
+        void this.notifyResourceUpdated(uri);
+      },
+    );
     this.unsubscribeToolsetChanges =
       options.onToolsetMayHaveChanged?.(() => {
         void this.notifyCurrentToolListChanged(options.gateway);
@@ -184,35 +202,49 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
       };
     });
 
-    this.server.setRequestHandler(CallToolRequestSchema, async (request): Promise<CallToolResult> => {
-      const previousSignature = await this.ensureToolsSignature(options.gateway);
-      const args = this.normalizeToolArguments(request.params.arguments);
-      const toolResult = this.isBridgeToolName(request.params.name)
-        ? await this.callBridgeTool(options, request.params.name, args)
-        : await options.gateway.callTool(request.params.name, args);
-      await this.notifyIfToolsChanged(options.gateway, previousSignature);
-      return this.toCallToolResult(toolResult);
-    });
+    this.server.setRequestHandler(
+      CallToolRequestSchema,
+      async (request): Promise<CallToolResult> => {
+        const previousSignature = await this.ensureToolsSignature(
+          options.gateway,
+        );
+        const args = this.normalizeToolArguments(request.params.arguments);
+        const toolResult = this.isBridgeToolName(request.params.name)
+          ? await this.callBridgeTool(options, request.params.name, args)
+          : await options.gateway.callTool(request.params.name, args);
+        await this.notifyIfToolsChanged(options.gateway, previousSignature);
+        await this.notifyLifecycleSnapshot(options.bridgeControl.getState());
+        return this.toCallToolResult(toolResult);
+      },
+    );
 
     this.server.setRequestHandler(ListResourcesRequestSchema, async () => {
       const resources = await this.listResources(options.gateway);
       return {
-        resources: resources.map((resource) => this.toMcpResourceDefinition(resource)),
+        resources: resources.map((resource) =>
+          this.toMcpResourceDefinition(resource),
+        ),
       };
     });
 
-    this.server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
-      const resource = await options.gateway.readResource(request.params.uri);
-      return {
-        contents: [
-          this.toMcpResourceContents(
-            request.params.uri,
-            resource,
-            await this.resolveResourceMimeType(options.gateway, request.params.uri),
-          ),
-        ],
-      };
-    });
+    this.server.setRequestHandler(
+      ReadResourceRequestSchema,
+      async (request) => {
+        const resource = await options.gateway.readResource(request.params.uri);
+        return {
+          contents: [
+            this.toMcpResourceContents(
+              request.params.uri,
+              resource,
+              await this.resolveResourceMimeType(
+                options.gateway,
+                request.params.uri,
+              ),
+            ),
+          ],
+        };
+      },
+    );
 
     this.server.setRequestHandler(SubscribeRequestSchema, async (request) => {
       this.subscribedResourceUris.add(request.params.uri);
@@ -224,9 +256,12 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
       return {};
     });
 
-    this.server.setRequestHandler(UxcCanReapRequestSchema, async () => {
-      return this.resolveCanReapResult(options.bridgeControl.getState());
-    });
+    this.server.setRequestHandler(
+      UxcLifecycleContractRequestSchema,
+      async () => {
+        return this.resolveLifecycleContract();
+      },
+    );
   }
 
   async start(): Promise<void> {
@@ -270,8 +305,15 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
     return {};
   }
 
-  private resolveCanReapResult(state: LocalBridgeState): McpCanReapResult {
-    const ownsExternalResource = state.ownership !== "none";
+  private resolveLifecycleContract(): McpLifecycleContractResult {
+    return {
+      reap_policy: "stateful",
+    };
+  }
+
+  private resolveLifecycleSnapshot(
+    state: LocalBridgeState,
+  ): Omit<McpLifecycleSnapshot, "updated_at_unix"> {
     const waitingForHuman =
       state.controlMode === "bootstrap" ||
       state.authState === "auth_required" ||
@@ -282,47 +324,61 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
 
     if (waitingForHuman) {
       return {
-        can_reap: false,
-        reason: "waiting_for_human",
-        retry_after_secs: CAN_REAP_RETRY_AFTER_SECS,
-        state: {
-          interactive: true,
-          owns_external_resource: ownsExternalResource,
-          waiting_for_human: true,
-        },
+        auto_reap_allowed: false,
+        retention_reason: "waiting_for_human",
+        retry_after_secs: LIFECYCLE_RETRY_AFTER_SECS,
       };
     }
 
     if (state.presentationMode === "headed") {
       return {
-        can_reap: false,
-        reason: "interactive_headed_session",
-        retry_after_secs: CAN_REAP_RETRY_AFTER_SECS,
-        state: {
-          interactive: true,
-          owns_external_resource: ownsExternalResource,
-          waiting_for_human: false,
-        },
+        auto_reap_allowed: false,
+        retention_reason: "interactive",
+        retry_after_secs: LIFECYCLE_RETRY_AFTER_SECS,
       };
     }
 
     return {
-      can_reap: true,
-      reason: state.mode === "control-only" ? "idle_control_plane" : "idle_headless_session",
-      state: {
-        interactive: false,
-        owns_external_resource: ownsExternalResource,
-        waiting_for_human: false,
-      },
+      auto_reap_allowed: true,
     };
   }
 
-  private toMcpResourceDefinition(resource: WebMcpResourceDefinition): Record<string, unknown> {
+  private async notifyLifecycleSnapshot(
+    state: LocalBridgeState,
+    force = false,
+  ): Promise<void> {
+    const baseSnapshot = this.resolveLifecycleSnapshot(state);
+    const signature = JSON.stringify(baseSnapshot);
+    if (!force && this.lastLifecycleSignature === signature) {
+      return;
+    }
+    this.lastLifecycleSignature = signature;
+    await this.server
+      .notification({
+        method: "notifications/uxc.lifecycle_changed",
+        params: {
+          ...baseSnapshot,
+          updated_at_unix: Math.floor(Date.now() / 1000),
+        },
+      })
+      .catch(() => {
+        // Lifecycle notification delivery is best-effort; the next state change or request
+        // can refresh the snapshot again.
+      });
+  }
+
+  private toMcpResourceDefinition(
+    resource: WebMcpResourceDefinition,
+  ): Record<string, unknown> {
     return {
       uri: resource.uri,
       ...(resource.name !== undefined ? { name: resource.name } : {}),
-      ...(resource.description !== undefined ? { description: resource.description } : {}),
-      ...(resource.mimeType !== undefined ? { mimeType: resource.mimeType } : {}),
+      ...(resource.description !== undefined
+        ? { description: resource.description }
+        : {}),
+      ...(resource.mimeType !== undefined
+        ? { mimeType: resource.mimeType }
+        : {}),
     };
   }
 
@@ -366,11 +422,15 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
     return typeof value === "object" && value !== null && !Array.isArray(value);
   }
 
-  private isContentArray(value: unknown): value is Array<Record<string, unknown>> {
+  private isContentArray(
+    value: unknown,
+  ): value is Array<Record<string, unknown>> {
     if (!Array.isArray(value)) {
       return false;
     }
-    return value.every((item) => this.isRecord(item) && typeof item.type === "string");
+    return value.every(
+      (item) => this.isRecord(item) && typeof item.type === "string",
+    );
   }
 
   private isCallToolResultPayload(value: JsonValue): boolean {
@@ -406,7 +466,9 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
     return "error" in value;
   }
 
-  private async ensureToolsSignature(gateway: LocalMcpGateway): Promise<string> {
+  private async ensureToolsSignature(
+    gateway: LocalMcpGateway,
+  ): Promise<string> {
     if (this.lastToolsSignature !== undefined) {
       return this.lastToolsSignature;
     }
@@ -416,7 +478,10 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
     return signature;
   }
 
-  private async notifyIfToolsChanged(gateway: LocalMcpGateway, previousSignature: string): Promise<void> {
+  private async notifyIfToolsChanged(
+    gateway: LocalMcpGateway,
+    previousSignature: string,
+  ): Promise<void> {
     const tools = await gateway.listTools();
     const nextTools = [...this.bridgeTools(), ...tools];
     const nextSignature = this.computeToolsSignature(nextTools);
@@ -429,7 +494,9 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
     });
   }
 
-  private async notifyCurrentToolListChanged(gateway: LocalMcpGateway): Promise<void> {
+  private async notifyCurrentToolListChanged(
+    gateway: LocalMcpGateway,
+  ): Promise<void> {
     this.toolsetNotification = this.toolsetNotification
       .catch(() => {
         // Keep the chain alive after previous notification failures.
@@ -438,9 +505,11 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
         if (this.lastToolsSignature === undefined) {
           return;
         }
-        await this.notifyIfToolsChanged(gateway, this.lastToolsSignature).catch((error) => {
-          this.onError?.(error);
-        });
+        await this.notifyIfToolsChanged(gateway, this.lastToolsSignature).catch(
+          (error) => {
+            this.onError?.(error);
+          },
+        );
       });
     await this.toolsetNotification;
   }
@@ -479,12 +548,14 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
     return [
       {
         name: "bridge.window.open",
-        description: "Open or focus the browser window for the current headed local-mcp session.",
+        description:
+          "Open or focus the browser window for the current headed local-mcp session.",
         inputSchema: { type: "object", additionalProperties: false },
       },
       {
         name: "bridge.session.status",
-        description: "Return local-mcp bridge session state for the current site session.",
+        description:
+          "Return local-mcp bridge session state for the current site session.",
         inputSchema: { type: "object", additionalProperties: false },
         annotations: {
           readOnlyHint: true,
@@ -492,12 +563,14 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
       },
       {
         name: "bridge.session.bootstrap",
-        description: "Launch a normal browser for manual sign-in on the managed site profile.",
+        description:
+          "Launch a normal browser for manual sign-in on the managed site profile.",
         inputSchema: { type: "object", additionalProperties: false },
       },
       {
         name: "bridge.session.attach",
-        description: "Restart the current local-mcp bridge session in attach mode against an existing Chromium browser.",
+        description:
+          "Restart the current local-mcp bridge session in attach mode against an existing Chromium browser.",
         inputSchema: {
           type: "object",
           properties: {
@@ -510,7 +583,8 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
       },
       {
         name: "bridge.session.mode.get",
-        description: "Return the current runtime presentation mode for the local-mcp bridge session.",
+        description:
+          "Return the current runtime presentation mode for the local-mcp bridge session.",
         inputSchema: { type: "object", additionalProperties: false },
         annotations: {
           readOnlyHint: true,
@@ -518,7 +592,8 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
       },
       {
         name: "bridge.session.mode.set",
-        description: "Switch the managed local-mcp bridge runtime between headed and headless presentation modes.",
+        description:
+          "Switch the managed local-mcp bridge runtime between headed and headless presentation modes.",
         inputSchema: {
           type: "object",
           properties: {
@@ -538,12 +613,14 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
       },
       {
         name: "bridge.session.reset_profile",
-        description: "Back up and reset the managed browser profile for the current local-mcp bridge session.",
+        description:
+          "Back up and reset the managed browser profile for the current local-mcp bridge session.",
         inputSchema: { type: "object", additionalProperties: false },
       },
       {
         name: "bridge.debug.eval",
-        description: "Run a debug-only page-context function in the current browser session and return a JSON-serializable result.",
+        description:
+          "Run a debug-only page-context function in the current browser session and return a JSON-serializable result.",
         inputSchema: {
           type: "object",
           properties: {
@@ -556,7 +633,8 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
       },
       {
         name: "bridge.overlay.list",
-        description: "List persisted overlays for the current site/profile scope.",
+        description:
+          "List persisted overlays for the current site/profile scope.",
         inputSchema: { type: "object", additionalProperties: false },
         annotations: {
           readOnlyHint: true,
@@ -564,7 +642,8 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
       },
       {
         name: "bridge.overlay.install",
-        description: "Persist a new overlay and load its tools into the current session.",
+        description:
+          "Persist a new overlay and load its tools into the current session.",
         inputSchema: {
           type: "object",
           properties: {
@@ -642,7 +721,8 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
       },
       {
         name: "bridge.overlay.enable",
-        description: "Enable a persisted overlay so its tools are listed in the current session.",
+        description:
+          "Enable a persisted overlay so its tools are listed in the current session.",
         inputSchema: {
           type: "object",
           properties: {
@@ -666,7 +746,8 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
       },
       {
         name: "bridge.overlay.delete",
-        description: "Delete a persisted overlay from the current site/profile scope.",
+        description:
+          "Delete a persisted overlay from the current site/profile scope.",
         inputSchema: {
           type: "object",
           properties: {
@@ -678,7 +759,8 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
       },
       {
         name: "bridge.overlay.export",
-        description: "Export a persisted overlay as a local TypeScript adapter draft.",
+        description:
+          "Export a persisted overlay as a local TypeScript adapter draft.",
         inputSchema: {
           type: "object",
           properties: {
@@ -701,7 +783,9 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
     ];
   }
 
-  private async listAllTools(options: LocalMcpStdioServerOptions): Promise<ReadonlyArray<WebMcpToolDefinition>> {
+  private async listAllTools(
+    options: LocalMcpStdioServerOptions,
+  ): Promise<ReadonlyArray<WebMcpToolDefinition>> {
     const pageTools = await options.gateway.listTools();
     return [...this.bridgeTools(), ...pageTools];
   }
@@ -729,18 +813,24 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
     );
   }
 
-  private parseOptionalBrowserUrl(input: Record<string, unknown>): string | undefined {
+  private parseOptionalBrowserUrl(
+    input: Record<string, unknown>,
+  ): string | undefined {
     const browserUrl = input.browserUrl;
     if (browserUrl === undefined) {
       return undefined;
     }
     if (typeof browserUrl !== "string" || !browserUrl.trim()) {
-      throw new Error("INVALID_ARGUMENT: browserUrl must be a non-empty string when provided");
+      throw new Error(
+        "INVALID_ARGUMENT: browserUrl must be a non-empty string when provided",
+      );
     }
     return browserUrl.trim();
   }
 
-  private parsePresentationModeSetOptions(input: Record<string, unknown>): LocalBridgePresentationModeSetOptions {
+  private parsePresentationModeSetOptions(
+    input: Record<string, unknown>,
+  ): LocalBridgePresentationModeSetOptions {
     const mode = input.mode;
     if (mode === "headed" || mode === "headless") {
       return {
@@ -770,7 +860,10 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
     return id.trim();
   }
 
-  private parseOverlayTools(input: unknown, required: boolean): OverlayToolInput[] | undefined {
+  private parseOverlayTools(
+    input: unknown,
+    required: boolean,
+  ): OverlayToolInput[] | undefined {
     if (input === undefined) {
       if (required) {
         throw new Error("INVALID_ARGUMENT: tools must be a non-empty array");
@@ -785,10 +878,14 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
         throw new Error(`INVALID_ARGUMENT: tools[${index}] must be an object`);
       }
       if (typeof entry.name !== "string" || !entry.name.trim()) {
-        throw new Error(`INVALID_ARGUMENT: tools[${index}].name must be a non-empty string`);
+        throw new Error(
+          `INVALID_ARGUMENT: tools[${index}].name must be a non-empty string`,
+        );
       }
       if (typeof entry.script !== "string" || !entry.script.trim()) {
-        throw new Error(`INVALID_ARGUMENT: tools[${index}].script must be a non-empty string`);
+        throw new Error(
+          `INVALID_ARGUMENT: tools[${index}].script must be a non-empty string`,
+        );
       }
       const tool: OverlayToolInput = {
         name: entry.name.trim(),
@@ -802,11 +899,15 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
       }
       if (entry.annotations !== undefined) {
         if (!this.isRecord(entry.annotations)) {
-          throw new Error(`INVALID_ARGUMENT: tools[${index}].annotations must be an object`);
+          throw new Error(
+            `INVALID_ARGUMENT: tools[${index}].annotations must be an object`,
+          );
         }
         const readOnlyHint = entry.annotations.readOnlyHint;
         if (readOnlyHint !== undefined && typeof readOnlyHint !== "boolean") {
-          throw new Error(`INVALID_ARGUMENT: tools[${index}].annotations.readOnlyHint must be a boolean`);
+          throw new Error(
+            `INVALID_ARGUMENT: tools[${index}].annotations.readOnlyHint must be a boolean`,
+          );
         }
         tool.annotations = {
           ...(typeof readOnlyHint === "boolean" ? { readOnlyHint } : {}),
@@ -816,7 +917,9 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
     });
   }
 
-  private parseOverlayActivation(input: Record<string, unknown>): OverlayActivation | undefined {
+  private parseOverlayActivation(
+    input: Record<string, unknown>,
+  ): OverlayActivation | undefined {
     const activation = input.activation;
     if (activation === undefined) {
       return undefined;
@@ -824,10 +927,14 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
     if (activation === "namespaced" || activation === "override") {
       return activation;
     }
-    throw new Error("INVALID_ARGUMENT: activation must be namespaced or override");
+    throw new Error(
+      "INVALID_ARGUMENT: activation must be namespaced or override",
+    );
   }
 
-  private parseOverlayInstallOptions(input: Record<string, unknown>): InstallOverlayOptions {
+  private parseOverlayInstallOptions(
+    input: Record<string, unknown>,
+  ): InstallOverlayOptions {
     const options: InstallOverlayOptions = {
       id: this.parseOverlayId(input),
       tools: this.parseOverlayTools(input.tools, true) ?? [],
@@ -845,7 +952,9 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
     return options;
   }
 
-  private parseOverlayUpdateOptions(input: Record<string, unknown>): UpdateOverlayOptions {
+  private parseOverlayUpdateOptions(
+    input: Record<string, unknown>,
+  ): UpdateOverlayOptions {
     const options: UpdateOverlayOptions = {
       id: this.parseOverlayId(input),
     };
@@ -893,7 +1002,9 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
           site: state.site,
           targetUrl: state.targetUrl,
           controlMode: state.controlMode,
-          ...(state.browserUrl !== undefined ? { browserUrl: state.browserUrl } : {}),
+          ...(state.browserUrl !== undefined
+            ? { browserUrl: state.browserUrl }
+            : {}),
           mode: state.mode,
           presentationMode: state.presentationMode,
           preferredPresentationMode: state.preferredPresentationMode,
@@ -910,7 +1021,9 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
           site: state.site,
           targetUrl: state.targetUrl,
           controlMode: state.controlMode,
-          ...(state.browserUrl !== undefined ? { browserUrl: state.browserUrl } : {}),
+          ...(state.browserUrl !== undefined
+            ? { browserUrl: state.browserUrl }
+            : {}),
           mode: state.mode,
           presentationMode: state.presentationMode,
           preferredPresentationMode: state.preferredPresentationMode,
@@ -918,9 +1031,15 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
           authState: state.authState,
           sessionState: state.sessionState,
           ownership: state.ownership,
-          ...(state.profilePath !== undefined ? { profilePath: state.profilePath } : {}),
-          ...(state.browserPid !== undefined ? { browserPid: state.browserPid } : {}),
-          ...(state.lastBackupPath !== undefined ? { lastBackupPath: state.lastBackupPath } : {}),
+          ...(state.profilePath !== undefined
+            ? { profilePath: state.profilePath }
+            : {}),
+          ...(state.browserPid !== undefined
+            ? { browserPid: state.browserPid }
+            : {}),
+          ...(state.lastBackupPath !== undefined
+            ? { lastBackupPath: state.lastBackupPath }
+            : {}),
         },
       };
     }
@@ -938,7 +1057,9 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
     }
     if (name === "bridge.session.attach") {
       try {
-        const nextState = await options.bridgeControl.attachSession(this.parseOptionalBrowserUrl(input));
+        const nextState = await options.bridgeControl.attachSession(
+          this.parseOptionalBrowserUrl(input),
+        );
         return {
           ok: true,
           session: nextState,
@@ -981,7 +1102,9 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
     }
     if (name === "bridge.overlay.install") {
       try {
-        const overlay = await options.bridgeControl.installOverlay(this.parseOverlayInstallOptions(input));
+        const overlay = await options.bridgeControl.installOverlay(
+          this.parseOverlayInstallOptions(input),
+        );
         return {
           ok: true,
           overlay,
@@ -993,7 +1116,9 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
     }
     if (name === "bridge.overlay.update") {
       try {
-        const overlay = await options.bridgeControl.updateOverlay(this.parseOverlayUpdateOptions(input));
+        const overlay = await options.bridgeControl.updateOverlay(
+          this.parseOverlayUpdateOptions(input),
+        );
         return {
           ok: true,
           overlay,
@@ -1005,7 +1130,9 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
     }
     if (name === "bridge.overlay.enable") {
       try {
-        const overlay = await options.bridgeControl.enableOverlay(this.parseOverlayId(input));
+        const overlay = await options.bridgeControl.enableOverlay(
+          this.parseOverlayId(input),
+        );
         return {
           ok: true,
           overlay,
@@ -1017,7 +1144,9 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
     }
     if (name === "bridge.overlay.disable") {
       try {
-        const overlay = await options.bridgeControl.disableOverlay(this.parseOverlayId(input));
+        const overlay = await options.bridgeControl.disableOverlay(
+          this.parseOverlayId(input),
+        );
         return {
           ok: true,
           overlay,
@@ -1042,7 +1171,9 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
     }
     if (name === "bridge.overlay.export") {
       try {
-        const exported = await options.bridgeControl.exportOverlay(this.parseOverlayId(input));
+        const exported = await options.bridgeControl.exportOverlay(
+          this.parseOverlayId(input),
+        );
         return {
           ok: true,
           exported: true,
@@ -1097,7 +1228,9 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
       site: state.site,
       targetUrl: state.targetUrl,
       controlMode: state.controlMode,
-      ...(state.browserUrl !== undefined ? { browserUrl: state.browserUrl } : {}),
+      ...(state.browserUrl !== undefined
+        ? { browserUrl: state.browserUrl }
+        : {}),
       mode: state.mode,
       presentationMode: state.presentationMode,
       preferredPresentationMode: state.preferredPresentationMode,
@@ -1105,19 +1238,29 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
       authState: state.authState,
       sessionState: state.sessionState,
       ownership: state.ownership,
-      ...(state.profilePath !== undefined ? { profilePath: state.profilePath } : {}),
-      ...(state.browserPid !== undefined ? { browserPid: state.browserPid } : {}),
-      ...(state.lastBackupPath !== undefined ? { lastBackupPath: state.lastBackupPath } : {}),
+      ...(state.profilePath !== undefined
+        ? { profilePath: state.profilePath }
+        : {}),
+      ...(state.browserPid !== undefined
+        ? { browserPid: state.browserPid }
+        : {}),
+      ...(state.lastBackupPath !== undefined
+        ? { lastBackupPath: state.lastBackupPath }
+        : {}),
       closing: true,
     };
   }
 
-  private computeToolsSignature(tools: ReadonlyArray<WebMcpToolDefinition>): string {
+  private computeToolsSignature(
+    tools: ReadonlyArray<WebMcpToolDefinition>,
+  ): string {
     const normalized = tools
       .map((tool) => ({
         annotations: this.normalizeForSignature(tool.annotations ?? {}),
         description: tool.description ?? "",
-        inputSchema: this.normalizeForSignature(tool.inputSchema ?? { type: "object" }),
+        inputSchema: this.normalizeForSignature(
+          tool.inputSchema ?? { type: "object" },
+        ),
         name: tool.name,
       }))
       .sort((a, b) => a.name.localeCompare(b.name));
@@ -1129,7 +1272,9 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
       return value.map((item) => this.normalizeForSignature(item));
     }
     if (typeof value === "object" && value !== null) {
-      const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b));
+      const entries = Object.entries(value as Record<string, unknown>).sort(
+        ([a], [b]) => a.localeCompare(b),
+      );
       const output: Record<string, unknown> = {};
       for (const [key, item] of entries) {
         output[key] = this.normalizeForSignature(item);
@@ -1140,6 +1285,8 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
   }
 }
 
-export function createLocalMcpStdioServer(options: LocalMcpStdioServerOptions): LocalMcpStdioServer {
+export function createLocalMcpStdioServer(
+  options: LocalMcpStdioServerOptions,
+): LocalMcpStdioServer {
   return new LocalMcpStdioServerImpl(options);
 }

--- a/packages/local-mcp/src/server.ts
+++ b/packages/local-mcp/src/server.ts
@@ -358,19 +358,19 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
     if (!force && this.lastLifecycleSignature === signature) {
       return;
     }
-    this.lastLifecycleSignature = signature;
-    await this.server
-      .notification({
+    try {
+      await this.server.notification({
         method: "notifications/uxc.lifecycle_changed",
         params: {
           ...baseSnapshot,
           updated_at_unix: Math.floor(Date.now() / 1000),
         },
       })
-      .catch(() => {
-        // Lifecycle notification delivery is best-effort; the next state change or request
-        // can refresh the snapshot again.
-      });
+      this.lastLifecycleSignature = signature;
+    } catch {
+      // Lifecycle notification delivery is best-effort; the next state change can refresh
+      // the snapshot again because the last delivered signature remains unchanged.
+    }
   }
 
   private toMcpResourceDefinition(

--- a/packages/local-mcp/src/server.ts
+++ b/packages/local-mcp/src/server.ts
@@ -105,6 +105,7 @@ export type LocalMcpStdioServerOptions = {
   gateway: LocalMcpGateway;
   bridgeControl: LocalBridgeControl;
   serviceVersion: string;
+  onLifecycleMayHaveChanged?: (listener: () => void) => () => void;
   onToolsetMayHaveChanged?: (listener: () => void) => () => void;
   input?: Readable;
   output?: Writable;
@@ -152,6 +153,7 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
   private readonly subscribedResourceUris = new Set<string>();
   private readonly resourceMimeTypes = new Map<string, string | undefined>();
   private readonly unsubscribeResourceUpdates: () => void;
+  private readonly unsubscribeLifecycleChanges: () => void;
   private readonly unsubscribeToolsetChanges: () => void;
   private toolsetNotification = Promise.resolve();
   private lastLifecycleSignature: string | undefined;
@@ -189,6 +191,10 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
         void this.notifyResourceUpdated(uri);
       },
     );
+    this.unsubscribeLifecycleChanges =
+      options.onLifecycleMayHaveChanged?.(() => {
+        void this.notifyLifecycleSnapshot(options.bridgeControl.getState());
+      }) ?? (() => {});
     this.unsubscribeToolsetChanges =
       options.onToolsetMayHaveChanged?.(() => {
         void this.notifyCurrentToolListChanged(options.gateway);
@@ -213,7 +219,6 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
           ? await this.callBridgeTool(options, request.params.name, args)
           : await options.gateway.callTool(request.params.name, args);
         await this.notifyIfToolsChanged(options.gateway, previousSignature);
-        await this.notifyLifecycleSnapshot(options.bridgeControl.getState());
         return this.toCallToolResult(toolResult);
       },
     );
@@ -278,6 +283,7 @@ class LocalMcpStdioServerImpl implements LocalMcpStdioServer {
     }
     this.closed = true;
     this.unsubscribeResourceUpdates();
+    this.unsubscribeLifecycleChanges();
     this.unsubscribeToolsetChanges();
     await this.server.close();
   }

--- a/packages/local-mcp/test/server.test.ts
+++ b/packages/local-mcp/test/server.test.ts
@@ -6,14 +6,21 @@
 import { PassThrough } from "node:stream";
 import type { JsonValue } from "@webmcp-bridge/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { McpCanReapResult, McpJsonRpcResponse } from "../src/mcp-types.js";
+import type {
+  McpJsonRpcResponse,
+  McpLifecycleContractResult,
+  McpLifecycleSnapshot,
+} from "../src/mcp-types.js";
 import {
   createLocalMcpStdioServer,
   type LocalMcpGateway,
   type LocalMcpStdioServer,
 } from "../src/server.js";
 
-async function waitFor(condition: () => boolean, timeoutMs = 1000): Promise<void> {
+async function waitFor(
+  condition: () => boolean,
+  timeoutMs = 1000,
+): Promise<void> {
   const start = Date.now();
   while (!condition()) {
     if (Date.now() - start >= timeoutMs) {
@@ -54,11 +61,15 @@ describe("createLocalMcpStdioServer", () => {
       mimeType: "application/json",
     },
   ]);
-  const readResource = vi.fn<(uri: string) => Promise<GatewayReadResourcePayload>>(async () => ({
+  const readResource = vi.fn<
+    (uri: string) => Promise<GatewayReadResourcePayload>
+  >(async () => ({
     version: 1,
     items: [],
   }));
-  const onResourceUpdated = vi.fn<LocalMcpGateway["onResourceUpdated"]>(() => () => {});
+  const onResourceUpdated = vi.fn<LocalMcpGateway["onResourceUpdated"]>(
+    () => () => {},
+  );
   let toolsetChangedListener: (() => void) | undefined;
 
   const gateway = {
@@ -81,7 +92,9 @@ describe("createLocalMcpStdioServer", () => {
       presentationMode: "headed" as const,
       preferredPresentationMode: "headed" as const,
     })),
-    openWindow: vi.fn<() => Promise<"focused" | "opened">>(async () => "focused" as const),
+    openWindow: vi.fn<() => Promise<"focused" | "opened">>(
+      async () => "focused" as const,
+    ),
     bootstrapSession: vi.fn(async () => ({
       site: "board",
       targetUrl: "http://127.0.0.1:4173",
@@ -165,8 +178,11 @@ describe("createLocalMcpStdioServer", () => {
       },
       format: "adapter-draft" as const,
       outputDir: "/tmp/board-profile/.webmcp-bridge/exports/board_fix",
-      entryFile: "/tmp/board-profile/.webmcp-bridge/exports/board_fix/src/index.ts",
-      files: ["/tmp/board-profile/.webmcp-bridge/exports/board_fix/src/index.ts"],
+      entryFile:
+        "/tmp/board-profile/.webmcp-bridge/exports/board_fix/src/index.ts",
+      files: [
+        "/tmp/board-profile/.webmcp-bridge/exports/board_fix/src/index.ts",
+      ],
     })),
     getPresentationMode: vi.fn(() => "headed" as const),
     setPresentationMode: vi.fn(async () => ({
@@ -263,7 +279,9 @@ describe("createLocalMcpStdioServer", () => {
     output.end();
   });
 
-  async function request(payload: Record<string, unknown>): Promise<McpJsonRpcResponse> {
+  async function request(
+    payload: Record<string, unknown>,
+  ): Promise<McpJsonRpcResponse> {
     const requestId = payload.id;
     const beforeCount = frames.length;
     input.write(`${JSON.stringify(payload)}\n`);
@@ -274,7 +292,9 @@ describe("createLocalMcpStdioServer", () => {
     );
     const response = frames
       .slice(beforeCount)
-      .find((frame) => "id" in frame && frame.id === requestId) as McpJsonRpcResponse | undefined;
+      .find((frame) => "id" in frame && frame.id === requestId) as
+      | McpJsonRpcResponse
+      | undefined;
     if (!response) {
       throw new Error("response frame not found");
     }
@@ -305,7 +325,9 @@ describe("createLocalMcpStdioServer", () => {
       serverInfo: {
         name: "webmcp-bridge-local-mcp",
       },
-      instructions: expect.stringContaining("If help only shows bridge.* tools"),
+      instructions: expect.stringContaining(
+        "If help only shows bridge.* tools",
+      ),
       capabilities: {
         tools: {
           listChanged: true,
@@ -359,7 +381,9 @@ describe("createLocalMcpStdioServer", () => {
     toolsetChangedListener?.();
 
     await waitFor(() =>
-      frames.slice(beforeCount).some((frame) => frame.method === "notifications/tools/list_changed"),
+      frames
+        .slice(beforeCount)
+        .some((frame) => frame.method === "notifications/tools/list_changed"),
     );
 
     expect(frames.slice(beforeCount)).toContainEqual(
@@ -369,68 +393,101 @@ describe("createLocalMcpStdioServer", () => {
     );
   });
 
-  it("reports headed interactive sessions as not reapable", async () => {
+  it("reports a stateful lifecycle contract", async () => {
     const response = await request({
       jsonrpc: "2.0",
-      id: "1-can-reap",
-      method: "uxc/can_reap",
-      params: {
-        idle_for_secs: 650,
-        idle_ttl_secs: 600,
-      },
+      id: "1-lifecycle-contract",
+      method: "uxc/lifecycle_contract",
+      params: {},
     });
 
-    expect("result" in response ? (response.result as McpCanReapResult) : undefined).toEqual({
-      can_reap: false,
-      reason: "interactive_headed_session",
-      retry_after_secs: 30,
-      state: {
-        interactive: true,
-        owns_external_resource: true,
-        waiting_for_human: false,
-      },
+    expect(
+      "result" in response
+        ? (response.result as McpLifecycleContractResult)
+        : undefined,
+    ).toEqual({
+      reap_policy: "stateful",
     });
   });
 
-  it("reports bootstrap sessions as waiting for human input", async () => {
-    bridgeControl.getState.mockReturnValueOnce({
-      site: "google",
-      targetUrl: "https://gemini.google.com/app",
-      controlMode: "bootstrap",
-      authPolicyMode: "bootstrap_then_attach",
-      authState: "auth_required",
-      sessionState: "bootstrap_active",
-      ownership: "external",
-      mode: "control-only",
-      presentationMode: "headed",
-      preferredPresentationMode: "headed",
-      profilePath: "/tmp/google-profile",
-      browserPid: 1234,
-    } as unknown as BridgeState);
-
-    const response = await request({
+  it("emits an initial interactive lifecycle snapshot after initialized", async () => {
+    await request({
       jsonrpc: "2.0",
-      id: "2-can-reap",
-      method: "uxc/can_reap",
+      id: "2-init",
+      method: "initialize",
       params: {
-        idle_for_secs: 650,
-        idle_ttl_secs: 600,
+        protocolVersion: "2024-11-05",
+        capabilities: {
+          tools: {
+            listChanged: true,
+          },
+        },
+        clientInfo: {
+          name: "test-client",
+          version: "0.1.0-test",
+        },
       },
     });
 
-    expect("result" in response ? (response.result as McpCanReapResult) : undefined).toEqual({
-      can_reap: false,
-      reason: "waiting_for_human",
+    input.write(
+      `${JSON.stringify({
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+        params: {},
+      })}\n`,
+    );
+
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.method === "notifications/uxc.lifecycle_changed",
+      ),
+    );
+    const notification = frames.find(
+      (frame) => frame.method === "notifications/uxc.lifecycle_changed",
+    );
+    expect(notification?.params).toMatchObject({
+      auto_reap_allowed: false,
+      retention_reason: "interactive",
       retry_after_secs: 30,
-      state: {
-        interactive: true,
-        owns_external_resource: true,
-        waiting_for_human: true,
-      },
-    });
+    } satisfies Partial<McpLifecycleSnapshot>);
+    expect(
+      (notification?.params as McpLifecycleSnapshot | undefined)
+        ?.updated_at_unix,
+    ).toBeTypeOf("number");
   });
 
-  it("allows idle headless sessions to be reaped", async () => {
+  it("emits lifecycle updates when state becomes auto-reapable", async () => {
+    await request({
+      jsonrpc: "2.0",
+      id: "3-init",
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {
+          tools: {
+            listChanged: true,
+          },
+        },
+        clientInfo: {
+          name: "test-client",
+          version: "0.1.0-test",
+        },
+      },
+    });
+
+    input.write(
+      `${JSON.stringify({
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+        params: {},
+      })}\n`,
+    );
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.method === "notifications/uxc.lifecycle_changed",
+      ),
+    );
+
     bridgeControl.getState.mockReturnValueOnce({
       site: "board",
       targetUrl: "http://127.0.0.1:4173",
@@ -445,25 +502,30 @@ describe("createLocalMcpStdioServer", () => {
       browserPid: 4321,
     } as unknown as BridgeState);
 
-    const response = await request({
+    const beforeCount = frames.length;
+    await request({
       jsonrpc: "2.0",
-      id: "3-can-reap",
-      method: "uxc/can_reap",
+      id: "3a",
+      method: "tools/call",
       params: {
-        idle_for_secs: 650,
-        idle_ttl_secs: 600,
+        name: "ping",
+        arguments: {},
       },
     });
 
-    expect("result" in response ? (response.result as McpCanReapResult) : undefined).toEqual({
-      can_reap: true,
-      reason: "idle_headless_session",
-      state: {
-        interactive: false,
-        owns_external_resource: true,
-        waiting_for_human: false,
-      },
-    });
+    await waitFor(() =>
+      frames
+        .slice(beforeCount)
+        .some(
+          (frame) => frame.method === "notifications/uxc.lifecycle_changed",
+        ),
+    );
+    const notification = frames
+      .slice(beforeCount)
+      .find((frame) => frame.method === "notifications/uxc.lifecycle_changed");
+    expect(notification?.params).toMatchObject({
+      auto_reap_allowed: true,
+    } satisfies Partial<McpLifecycleSnapshot>);
   });
 
   it("proxies tools/list to gateway", async () => {
@@ -898,8 +960,12 @@ describe("createLocalMcpStdioServer", () => {
         },
       },
     });
-    expect("result" in response ? response.result?.content : undefined).toEqual([]);
-    expect("result" in response ? response.result?.isError : undefined).toBe(true);
+    expect("result" in response ? response.result?.content : undefined).toEqual(
+      [],
+    );
+    expect("result" in response ? response.result?.isError : undefined).toBe(
+      true,
+    );
   });
 
   it("handles bridge.session.attach locally", async () => {
@@ -915,7 +981,9 @@ describe("createLocalMcpStdioServer", () => {
       },
     });
 
-    expect(bridgeControl.attachSession).toHaveBeenCalledWith("http://127.0.0.1:9222");
+    expect(bridgeControl.attachSession).toHaveBeenCalledWith(
+      "http://127.0.0.1:9222",
+    );
     expect(callTool).not.toHaveBeenCalled();
     expect("result" in response ? response.result : undefined).toMatchObject({
       structuredContent: {
@@ -1052,7 +1120,9 @@ describe("createLocalMcpStdioServer", () => {
   });
 
   it("maps non-prefixed bridge control errors to a stable default code", async () => {
-    bridgeControl.setPresentationMode.mockRejectedValueOnce(new Error("plain restart failure"));
+    bridgeControl.setPresentationMode.mockRejectedValueOnce(
+      new Error("plain restart failure"),
+    );
 
     const response = await request({
       jsonrpc: "2.0",
@@ -1224,7 +1294,9 @@ describe("createLocalMcpStdioServer", () => {
 
     expect(listResources).toHaveBeenCalledOnce();
     expect("result" in response ? response.result : undefined).toMatchObject({
-      resources: [{ uri: "board://local/interactions", name: "Board Interactions" }],
+      resources: [
+        { uri: "board://local/interactions", name: "Board Interactions" },
+      ],
     });
   });
 
@@ -1333,7 +1405,9 @@ describe("createLocalMcpStdioServer", () => {
     notifyResourceUpdated?.("board://local/interactions");
 
     await waitFor(() =>
-      frames.some((frame) => frame.method === "notifications/resources/updated"),
+      frames.some(
+        (frame) => frame.method === "notifications/resources/updated",
+      ),
     );
     const notification = frames.find(
       (frame) => frame.method === "notifications/resources/updated",
@@ -1346,7 +1420,9 @@ describe("createLocalMcpStdioServer", () => {
   });
 
   it("emits tools/list_changed after a tool call mutates available tools", async () => {
-    listTools.mockResolvedValueOnce([{ name: "navigate", description: "navigate" }]);
+    listTools.mockResolvedValueOnce([
+      { name: "navigate", description: "navigate" },
+    ]);
     listTools.mockResolvedValueOnce([
       { name: "navigate", description: "navigate" },
       { name: "search_entities", description: "search entities" },

--- a/packages/local-mcp/test/server.test.ts
+++ b/packages/local-mcp/test/server.test.ts
@@ -465,6 +465,62 @@ describe("createLocalMcpStdioServer", () => {
     ).toBeTypeOf("number");
   });
 
+  it("emits a waiting_for_human lifecycle snapshot for bootstrap state", async () => {
+    bridgeControl.getState.mockReturnValueOnce({
+      site: "board",
+      targetUrl: "http://127.0.0.1:4173",
+      controlMode: "bootstrap",
+      authPolicyMode: "bootstrap_then_attach",
+      authState: "auth_required",
+      sessionState: "bootstrap_active",
+      ownership: "external",
+      mode: "control-only",
+      presentationMode: "headed",
+      preferredPresentationMode: "headed",
+      profilePath: "/tmp/board-profile",
+    } as unknown as BridgeState);
+
+    await request({
+      jsonrpc: "2.0",
+      id: "2a-init",
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {
+          tools: {
+            listChanged: true,
+          },
+        },
+        clientInfo: {
+          name: "test-client",
+          version: "0.1.0-test",
+        },
+      },
+    });
+
+    input.write(
+      `${JSON.stringify({
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+        params: {},
+      })}\n`,
+    );
+
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.method === "notifications/uxc.lifecycle_changed",
+      ),
+    );
+    const notification = frames.find(
+      (frame) => frame.method === "notifications/uxc.lifecycle_changed",
+    );
+    expect(notification?.params).toMatchObject({
+      auto_reap_allowed: false,
+      retention_reason: "waiting_for_human",
+      retry_after_secs: 30,
+    } satisfies Partial<McpLifecycleSnapshot>);
+  });
+
   it("emits lifecycle updates when lifecycle listener reports auto-reapable state", async () => {
     await request({
       jsonrpc: "2.0",

--- a/packages/local-mcp/test/server.test.ts
+++ b/packages/local-mcp/test/server.test.ts
@@ -70,6 +70,7 @@ describe("createLocalMcpStdioServer", () => {
   const onResourceUpdated = vi.fn<LocalMcpGateway["onResourceUpdated"]>(
     () => () => {},
   );
+  let lifecycleChangedListener: (() => void) | undefined;
   let toolsetChangedListener: (() => void) | undefined;
 
   const gateway = {
@@ -258,6 +259,14 @@ describe("createLocalMcpStdioServer", () => {
       gateway,
       bridgeControl,
       serviceVersion: "0.1.0-test",
+      onLifecycleMayHaveChanged: (listener) => {
+        lifecycleChangedListener = listener;
+        return () => {
+          if (lifecycleChangedListener === listener) {
+            lifecycleChangedListener = undefined;
+          }
+        };
+      },
       onToolsetMayHaveChanged: (listener) => {
         toolsetChangedListener = listener;
         return () => {
@@ -456,7 +465,7 @@ describe("createLocalMcpStdioServer", () => {
     ).toBeTypeOf("number");
   });
 
-  it("emits lifecycle updates when state becomes auto-reapable", async () => {
+  it("emits lifecycle updates when lifecycle listener reports auto-reapable state", async () => {
     await request({
       jsonrpc: "2.0",
       id: "3-init",
@@ -503,15 +512,7 @@ describe("createLocalMcpStdioServer", () => {
     } as unknown as BridgeState);
 
     const beforeCount = frames.length;
-    await request({
-      jsonrpc: "2.0",
-      id: "3a",
-      method: "tools/call",
-      params: {
-        name: "ping",
-        arguments: {},
-      },
-    });
+    lifecycleChangedListener?.();
 
     await waitFor(() =>
       frames
@@ -1270,12 +1271,12 @@ describe("createLocalMcpStdioServer", () => {
     expect("error" in response ? response.error.code : undefined).toBe(-32601);
   });
 
-  it("does not respond to notifications", async () => {
+  it("does not respond to unrelated notifications", async () => {
     const beforeCount = frames.length;
     input.write(
       `${JSON.stringify({
         jsonrpc: "2.0",
-        method: "notifications/initialized",
+        method: "notifications/example",
         params: {},
       })}\n`,
     );


### PR DESCRIPTION
## What
- implement `uxc/lifecycle_contract` in `local-mcp` and return `stateful`
- emit `notifications/uxc.lifecycle_changed` after initialization and whenever effective auto-reap eligibility changes
- replace old `can_reap`-oriented tests with lifecycle contract/snapshot coverage

## Why
- `local-mcp` should report lifecycle state proactively instead of being probed through a competing stdio request
- this matches the new UXC daemon session lifecycle contract

## How
- add lifecycle contract and snapshot types
- map browser bridge state into generic `auto_reap_allowed` / `retention_reason` snapshots
- push deduplicated lifecycle notifications through the MCP server

## Testing
- `pnpm exec prettier --check src/server.ts src/mcp-types.ts test/server.test.ts`
- `pnpm --filter @webmcp-bridge/local-mcp typecheck`
- `pnpm --filter @webmcp-bridge/local-mcp test -- --runInBand packages/local-mcp/test/server.test.ts`

Part of holon-run/webmcp-bridge#67.